### PR TITLE
Add Orion to the "Browsers" category

### DIFF
--- a/Applite/Resources/categories.json
+++ b/Applite/Resources/categories.json
@@ -10,6 +10,7 @@
             "microsoft-edge",
             "opera",
             "opera-gx",
+            "orion",
             "tor-browser",
             "vivaldi"
         ],


### PR DESCRIPTION
First, thank you for this great project, I enjoy using Applite a lot! ❤️ 

Orion (https://browser.kagi.com) is another browser that would be nice to see in the "Browsers" category.

:octocat: 