### PR TITLE
slight adjustments to the settings window

### DIFF
--- a/Applite/Components/BrewPathSelectorView.swift
+++ b/Applite/Components/BrewPathSelectorView.swift
@@ -10,37 +10,36 @@ import SwiftUI
 /// Provides a picker so the user can select the brew executable path they want to use
 struct BrewPathSelectorView: View {
     @Binding var isSelectedPathValid: Bool
-    
+
     @StateObject var customBrewPathDebounced = DebounceObject()
-    
+
     @AppStorage("customUserBrewPath") var customUserBrewPath: String = BrewPaths.getBrewExectuablePath(for: .defaultAppleSilicon, shellFriendly: false)
     @AppStorage("brewPathOption") var brewPathOption = BrewPaths.PathOption.defaultAppleSilicon.rawValue
-    
-    private func getPathDesctiption(for option: BrewPaths.PathOption) -> String {
+
+    private func getPathDescription(for option: BrewPaths.PathOption) -> String {
         switch option {
         case .appPath:
             return "\(Bundle.main.appName)'s installation"
-            
+
         case .defaultAppleSilicon:
-            return "Apple Silicon mac"
-            
+            return "Apple Silicon Mac"
+
         case .defaultIntel:
-            return "Intel mac"
-            
+            return "Intel Mac"
+
         case .custom:
             return ""
         }
     }
-    
+
     var body: some View {
         VStack(alignment: .leading) {
             Picker("", selection: $brewPathOption) {
                 ForEach(BrewPaths.PathOption.allCases) { option in
                     if option != .custom {
                         HStack {
-                            Text("\(BrewPaths.getBrewExectuablePath(for: option, shellFriendly: false)) (\(getPathDesctiption(for: option)))")
-                                .truncationMode(.middle)
-                            
+                            Text("\(getPathDescription(for: option))")
+                            Text("(\(BrewPaths.getBrewExectuablePath(for: option, shellFriendly: false)))").truncationMode(.middle).lineLimit(1).foregroundColor(.gray)
                             if option.rawValue == brewPathOption {
                                 if isSelectedPathValid {
                                     Image(systemName: "checkmark.circle")
@@ -58,7 +57,7 @@ struct BrewPathSelectorView: View {
                         VStack(alignment: .leading, spacing: 5) {
                             HStack {
                                 Text("Custom")
-                                
+
                                 if option.rawValue == brewPathOption {
                                     if isSelectedPathValid {
                                         Image(systemName: "checkmark.circle")
@@ -71,7 +70,7 @@ struct BrewPathSelectorView: View {
                                     }
                                 }
                             }
-                            
+
                             TextField("Custom brew path", text: $customBrewPathDebounced.text, prompt: Text("/path/to/brew"))
                                 .textFieldStyle(.roundedBorder)
                                 .frame(maxWidth: 300)
@@ -93,7 +92,7 @@ struct BrewPathSelectorView: View {
         }
         .onChange(of: customBrewPathDebounced.debouncedText) { newPath in
             customUserBrewPath = newPath
-            
+
             if brewPathOption == BrewPaths.PathOption.custom.rawValue {
                 isSelectedPathValid = isBrewPathValid(path: newPath)
             }

--- a/Applite/Views/SettingsView.swift
+++ b/Applite/Views/SettingsView.swift
@@ -13,31 +13,31 @@ public enum ColorSchemePreference: String, CaseIterable, Identifiable {
     case system
     case light
     case dark
-    
+
     public var id: Self { self }
 }
 
 /// Settings pane
 struct SettingsView: View {
     let updater: SPUUpdater
-    
+
     var body: some View {
         TabView {
             GeneralSettingsView()
                 .tabItem {
                     Label("General", systemImage: "gearshape")
                 }
-            
+
             BrewPathView()
                 .tabItem {
                     Label("Brew Path", systemImage: "mug")
                 }
-            
+
             UpdateSettingsView(updater: updater)
                 .tabItem {
                     Label("Updates", systemImage: "arrow.clockwise")
                 }
-            
+
             UninstallView()
                 .tabItem {
                     Label("Uninstall", systemImage: "trash")
@@ -53,7 +53,7 @@ struct SettingsView: View {
                 NSApp.keyWindow?.makeFirstResponder(nil)
             }
         }
-        .frame(width: 400, height: 260)
+        .frame(width: 400)
     }
 }
 
@@ -61,30 +61,28 @@ fileprivate struct GeneralSettingsView: View {
     @AppStorage("colorSchemePreference") var colorSchemePreference: ColorSchemePreference = .system
     @AppStorage("notificationSuccess") var notificationOnSuccess: Bool = false
     @AppStorage("notificationFailure") var notificationOnFailure: Bool = true
-    
+
     var body: some View {
         VStack(alignment: .leading) {
             Text("Appearance")
                 .bold()
-            
+
             Picker("Color Scheme:", selection: $colorSchemePreference) {
-                
+
                 ForEach(ColorSchemePreference.allCases) { color in
                     Text(NSLocalizedString(color.rawValue.capitalized, comment: "Colors schemes names"))
                 }
             }
             .pickerStyle(.segmented)
-            
+
             Divider()
                 .padding(.vertical)
-            
+
             Text("Notifications")
                 .bold()
 
             Toggle("Task completions", isOn: $notificationOnSuccess)
             Toggle("Task errors", isOn: $notificationOnFailure)
-            
-            Spacer()
         }
         .padding()
     }
@@ -93,28 +91,27 @@ fileprivate struct GeneralSettingsView: View {
 fileprivate struct BrewPathView: View {
     @AppStorage("customUserBrewPath") var customUserBrewPath: String = "/opt/homebrew/bin/brew"
     @AppStorage("brewPathOption") var brewPathOption = BrewPaths.PathOption.appPath.rawValue
-    
+
     @State var isSelectedBrewPathValid = false
-    
+
     /// Brew installation option before making changes
     @State var previousBrewOption: Int = 0
-    
+
     var body: some View {
         VStack {
             Text("Brew Executable Path")
                 .bold()
-            
+
             BrewPathSelectorView(isSelectedPathValid: $isSelectedBrewPathValid)
-                .padding(.bottom, 4)
-            
+
             Text("Currently selected brew path is invalid")
                 .foregroundColor(.red)
                 .opacity(isSelectedBrewPathValid ? 0 : 1)
-            
+
             if previousBrewOption != brewPathOption && isSelectedBrewPathValid {
                 Text("Brew path has been modified. Restart app for changes to take effect.")
                     .foregroundColor(.red)
-                
+
                 Button("Relaunch", role: .destructive) {
                     Task {
                         await shell("/usr/bin/osascript -e 'tell application \"\(Bundle.main.appName)\" to quit' && sleep 2 && open \"/Applications/\(Bundle.main.appName).app\"")
@@ -122,55 +119,56 @@ fileprivate struct BrewPathView: View {
                 }
             }
         }
-        .padding()
         .onAppear {
             previousBrewOption = BrewPaths.selectedBrewOption.rawValue
         }
+        .padding()
     }
 }
 
 fileprivate struct UpdateSettingsView: View {
     private let updater: SPUUpdater
-    
+
     @State private var automaticallyChecksForUpdates: Bool
     @State private var automaticallyDownloadsUpdates: Bool
-    
+
     init(updater: SPUUpdater) {
         self.updater = updater
         self.automaticallyChecksForUpdates = updater.automaticallyChecksForUpdates
         self.automaticallyDownloadsUpdates = updater.automaticallyDownloadsUpdates
     }
-    
+
     var body: some View {
         VStack {
             CheckForUpdatesView(updater: updater) {
                 Label("Check for Updates...", systemImage: "arrow.uturn.down")
             }
-            
+
             Text("Current app version: \(Bundle.main.version) (\(Bundle.main.buildNumber))")
                 .font(.system(.body, weight: .light))
                 .foregroundColor(.secondary)
-            
+
             Spacer()
-                .frame(height: 30)
-            
+                .frame(height: 20)
+
             Toggle("Automatically check for updates", isOn: $automaticallyChecksForUpdates)
                 .onChange(of: automaticallyChecksForUpdates) { newValue in
                     updater.automaticallyChecksForUpdates = newValue
                 }
-            
+
             Toggle("Automatically download updates", isOn: $automaticallyDownloadsUpdates)
                 .disabled(!automaticallyChecksForUpdates)
                 .onChange(of: automaticallyDownloadsUpdates) { newValue in
                     updater.automaticallyDownloadsUpdates = newValue
                 }
-        }.padding()
+        }
+        .padding()
     }
 }
 
 fileprivate struct UninstallView: View {
     @Environment(\.openWindow) var openWindow
-    
+
     var body: some View {
         VStack(alignment: .center) {
             Button(role: .destructive) {
@@ -179,9 +177,9 @@ fileprivate struct UninstallView: View {
                 Label("Uninstall", systemImage: "trash.fill")
             }
             .bigButton(foregroundColor: .white, backgroundColor: .red)
-            
+
             Text("Uninstall \(Bundle.main.appName), related files and cache.")
-        }
+        }.padding()
     }
 }
 


### PR DESCRIPTION
- settings window does not have a fixed height (less white-space)
- brew path view is now locked to one line to avoid a jumping list
- brew path: shownthe platform and then the path (light grey)
- added spacing to the uninstall view
- less spacing the the update view