### PR TITLE
pinentry.ksh: add a timeout to pinentry-mac

### DIFF
--- a/Applite/Resources/pinentry.ksh
+++ b/Applite/Resources/pinentry.ksh
@@ -4,4 +4,4 @@
 typeset PATH="/opt/homebrew/bin:/usr/local/bin:${HOME}/Library/Application Support/Applite/homebrew/bin:${PATH}"
 
 # Prompt user for password and return it
-printf "%s\n" "SETOK OK" "SETCANCEL Cancel" "SETDESC Applite needs your admin password to complete the task" "SETPROMPT Enter Password:" "SETTITLE Applite Password Request" "GETPIN" | /usr/bin/env pinentry-mac --no-global-grab | /usr/bin/awk '/^D / {print substr($0, index($0, $2))}'
+printf "%s\n" "SETOK OK" "SETCANCEL Cancel" "SETDESC Applite needs your admin password to complete the task" "SETPROMPT Enter Password:" "SETTITLE Applite Password Request" "GETPIN" | /usr/bin/env pinentry-mac --no-global-grab --timeout 60 | /usr/bin/awk '/^D / {print substr($0, index($0, $2))}'

--- a/Applite/Utilities/Shell/PinentryScriptHash.swift
+++ b/Applite/Utilities/Shell/PinentryScriptHash.swift
@@ -8,4 +8,4 @@
 import Foundation
 
 /// MD5 hash of the pinentry.ksh file
-let pinentryScriptHash = "xEAHWuD1eAqgO7XO+/cfmg=="
+let pinentryScriptHash = "AnfcWA+MzXeqGOc3oQHu0Q=="


### PR DESCRIPTION
Adds a timeout to `pinentry-mac`. This way, if Applite attempts a brew command which invokes sudo via `SUDO_ASKPASS` when the user is not available to enter the admin password, the brew task on that cask can fail and any remaining ones can proceed.

The timeout is in seconds, so 1 minute. This is, of course, arbitrary and you might have a different thought about how long to make it.