### PR TITLE
fix typo `Kinfisher` -> `Kingfisher`

### DIFF
--- a/Applite/AppliteApp.swift
+++ b/Applite/AppliteApp.swift
@@ -36,7 +36,7 @@ struct AppliteApp: App {
     init() {
         updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
 
-        // Setup network proxy for Kinfisher
+        // Setup network proxy for Kingfisher
         KingfisherManager.shared.downloader.sessionConfiguration = NetworkProxyManager.getURLSessionConfiguration()
     }
     


### PR DESCRIPTION
fixed a typo `Kinfisher` -> `Kingfisher`