### PR TITLE
Feature Add Homebrew Official Uninstall Script Support and Bug Fix for Buttonkit Dep

### DIFF
--- a/Applite.xcodeproj/project.pbxproj
+++ b/Applite.xcodeproj/project.pbxproj
@@ -1254,7 +1254,7 @@
 		};
 		413F87332D34109000D4BE10 /* XCRemoteSwiftPackageReference "ButtonKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Dean151/ButtonKit?tab=readme-ov-file";
+			repositoryURL = "https://github.com/Dean151/ButtonKit";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 0.6.1;

--- a/Applite/Utilities/Other/UninstallSelf.swift
+++ b/Applite/Utilities/Other/UninstallSelf.swift
@@ -25,19 +25,19 @@ func uninstallSelf(deleteBrewCache: Bool, uninstallHomebrew: Bool = false) async
 
     logger.notice("Deleting library files")
 
-    // Delete related files and cache
+    // Delete related files and cache (using -rf to ignore missing files)
     let command = """
-    rm -r "$HOME/Library/Application Support/Applite";
-    rm -r "$HOME/Library/Application Support/\(Bundle.main.bundleIdentifier!)";
-    rm -r $HOME/Library/Containers/\(Bundle.main.bundleIdentifier!);
-    rm -r $HOME/Library/Caches/Applite;
-    rm -r $HOME/Library/Caches/\(Bundle.main.bundleIdentifier!);
-    rm -r $HOME/Library/Applite;
-    rm -r $HOME/Library/Preferences/*\(Bundle.main.bundleIdentifier!)*.plist;
-    rm -r "$HOME/Library/Saved Application State/\(Bundle.main.bundleIdentifier!).savedState";
-    rm -r $HOME/Library/SyncedPreferences/\(Bundle.main.bundleIdentifier!)*.plist;
-    rm -r $HOME/Library/WebKit/\(Bundle.main.bundleIdentifier!);
-    rm -r $HOME/Library/HTTPStorages/dev.aerolite.Applite
+    rm -rf "$HOME/Library/Application Support/Applite";
+    rm -rf "$HOME/Library/Application Support/\(Bundle.main.bundleIdentifier!)";
+    rm -rf $HOME/Library/Containers/\(Bundle.main.bundleIdentifier!);
+    rm -rf $HOME/Library/Caches/Applite;
+    rm -rf $HOME/Library/Caches/\(Bundle.main.bundleIdentifier!);
+    rm -rf $HOME/Library/Applite;
+    rm -rf $HOME/Library/Preferences/*\(Bundle.main.bundleIdentifier!)*.plist;
+    rm -rf "$HOME/Library/Saved Application State/\(Bundle.main.bundleIdentifier!).savedState";
+    rm -rf $HOME/Library/SyncedPreferences/\(Bundle.main.bundleIdentifier!)*.plist;
+    rm -rf $HOME/Library/WebKit/\(Bundle.main.bundleIdentifier!);
+    rm -rf $HOME/Library/HTTPStorages/dev.aerolite.Applite
     """
     
     logger.notice("Running command: \(command)")

--- a/Applite/Utilities/Other/UninstallSelf.swift
+++ b/Applite/Utilities/Other/UninstallSelf.swift
@@ -88,6 +88,14 @@ private func uninstallHomebrewCompletely() async throws {
         
         // Check if it's a ShellError and provide better error message
         if case .nonZeroExit(_, let exitCode, let output) = error as? ShellError {
+            // Handle case where Homebrew is not found (this is not really an error)
+            if output.contains("Failed to locate Homebrew") || 
+               output.contains("Homebrew is not installed") ||
+               output.contains("No such file or directory") && output.contains("brew") {
+                logger.notice("Homebrew not found - it may already be uninstalled or never installed")
+                return // Exit successfully since there's nothing to uninstall
+            }
+            
             if exitCode == 127 || output.contains("Permission denied") || output.contains("sudo") || output.contains("administrator") {
                 throw NSError(
                     domain: "HomebrewUninstallError",

--- a/Applite/Views/UninstallSelfView.swift
+++ b/Applite/Views/UninstallSelfView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 /// Uninstalls Applite and related files
 struct UninstallSelfView: View {
     @State var deleteBrewCache = false
+    @State var uninstallHomebrew = false
     @State var showConfirmation = false
 
     @StateObject var uninstallAlert = AlertManager()
@@ -23,11 +24,25 @@ struct UninstallSelfView: View {
             Text("This will uninstall all files and cache associated with Applite.", comment: "Uninstall applite window description")
 
             Toggle("Delete Homebrew cache", isOn: $deleteBrewCache)
+                .disabled(uninstallHomebrew)
             
             Text(
                 "**Warning**: Homebrew cache is shared between Homebrew installations. Deleting the cache will remove the cache for all installations!",
                 comment: "Uninstall Applite window cache warning"
             )
+            
+            Toggle("Uninstall Homebrew", isOn: $uninstallHomebrew)
+                .onChange(of: uninstallHomebrew) { newValue in
+                    if newValue {
+                        deleteBrewCache = true
+                    }
+                }
+            
+            Text(
+                "**Warning**: This will run the Homebrew uninstaller and remove Homebrew from all known locations and all packages installed.",
+                comment: "Uninstall Homebrew warning"
+            )
+            .opacity(uninstallHomebrew ? 1 : 0)
 
             Divider()
                 .padding(.vertical)
@@ -43,12 +58,12 @@ struct UninstallSelfView: View {
 
             Spacer()
         }
-        .frame(width: 400, height: 250)
+        .frame(width: 400, height: 320)
         .confirmationDialog("Are you sure you want to permanently uninstall Applite?", isPresented: $showConfirmation) {
             Button("Uninstall", role: .destructive) {
                 Task.detached {
                     do {
-                        try await uninstallSelf(deleteBrewCache: deleteBrewCache)
+                        try await uninstallSelf(deleteBrewCache: deleteBrewCache, uninstallHomebrew: uninstallHomebrew)
                     } catch {
                         await uninstallAlert.show(title: "Failed to uninstall", message: error.localizedDescription)
                     }

--- a/Applite/Views/UninstallSelfView.swift
+++ b/Applite/Views/UninstallSelfView.swift
@@ -39,10 +39,9 @@ struct UninstallSelfView: View {
                 }
             
             Text(
-                "**Warning**: This will run the Homebrew uninstaller and remove Homebrew from all known locations and all packages installed.",
+                "**Warning**: This will run the Homebrew uninstaller and remove Homebrew from all known locations and all packages installed. Administrator privileges may be required.",
                 comment: "Uninstall Homebrew warning"
             )
-            .opacity(uninstallHomebrew ? 1 : 0)
 
             Divider()
                 .padding(.vertical)


### PR DESCRIPTION
As a feature item, added support for when you uninstall Applite, it provides an additional checkbox to allow pulling the official Homebrew Uninstall script and runing this to account for fully removing Homebrew from all locations on a device (and all installed packages).  This can also help repair/clear out bad installs as well and allow someone to re-install the App in case of issues that occur as well!

Bug fix also added to remove a reference to Buttonkit source incorrectly - [https://github.com/milanvarady/Applite/issues/117](https://github.com/milanvarady/Applite/issues/117)