### PR TITLE
Replace 6 third-party SPM dependencies with native code

### DIFF
--- a/Applite.xcodeproj/project.pbxproj
+++ b/Applite.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5CDD639E54F54A68FEC0B100 /* ICloudSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A09CD81CE6DEB059908E50 /* ICloudSyncManager.swift */; };
+		95F476538772FD39D3F5E464 /* AppHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEB7F231C539AFA252E37854 /* AppHistoryView.swift */; };
 		4101EB332DCE022B00BE0670 /* CaskNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4101EB322DCE022B00BE0670 /* CaskNetworkService.swift */; };
 		4101EB352DCE033C00BE0670 /* CaskCacheService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4101EB342DCE033C00BE0670 /* CaskCacheService.swift */; };
 		4101EB372DCE03F700BE0670 /* InstalledCaskService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4101EB362DCE03F700BE0670 /* InstalledCaskService.swift */; };
@@ -164,6 +166,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		E1A09CD81CE6DEB059908E50 /* ICloudSyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICloudSyncManager.swift; sourceTree = "<group>"; };
+		BEB7F231C539AFA252E37854 /* AppHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHistoryView.swift; sourceTree = "<group>"; };
 		4101EB322DCE022B00BE0670 /* CaskNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskNetworkService.swift; sourceTree = "<group>"; };
 		4101EB342DCE033C00BE0670 /* CaskCacheService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaskCacheService.swift; sourceTree = "<group>"; };
 		4101EB362DCE03F700BE0670 /* InstalledCaskService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstalledCaskService.swift; sourceTree = "<group>"; };
@@ -569,6 +573,7 @@
 		4191393129269FD600F1D75D /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				E1A09CD81CE6DEB059908E50 /* ICloudSyncManager.swift */,
 				412635422A77FB0000155034 /* Brew Installation */,
 				4126353F2A77C71F00155034 /* Shell */,
 				41B731352A878993008BF6B9 /* App Migration */,
@@ -773,6 +778,7 @@
 		4196C8F728F9CB5200EADDDA /* Detail Views */ = {
 			isa = PBXGroup;
 			children = (
+				BEB7F231C539AFA252E37854 /* AppHistoryView.swift */,
 				413F872A2D33E18800D4BE10 /* Home */,
 				419256502D1E0CE000D9EF10 /* Discover */,
 				4192565C2D1E153D00D9EF10 /* Update */,
@@ -891,6 +897,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5CDD639E54F54A68FEC0B100 /* ICloudSyncManager.swift in Sources */,
+				95F476538772FD39D3F5E464 /* AppHistoryView.swift in Sources */,
 				413F87322D33E30400D4BE10 /* SortingOptions.swift in Sources */,
 				4196C90028F9E1F400EADDDA /* InstalledView.swift in Sources */,
 				4101EB552DCE7FA000BE0670 /* MirrorEnvironment.swift in Sources */,

--- a/Applite.xcodeproj/project.pbxproj
+++ b/Applite.xcodeproj/project.pbxproj
@@ -27,6 +27,13 @@
 		4104D7432A8FC52C00F84F9B /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4104D7422A8FC52C00F84F9B /* Preferences.swift */; };
 		41062C952A3794EA00FD48EA /* BrewPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41062C942A3794EA00FD48EA /* BrewPaths.swift */; };
 		41062C972A3A20F900FD48EA /* UninstallSelf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41062C962A3A20F900FD48EA /* UninstallSelf.swift */; };
+		AA00000AAAAA00000000000A /* ShimmerModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000001AAAA000000000001 /* ShimmerModifier.swift */; };
+		AA00000BAAAA00000000000B /* DebouncedTaskModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000002AAAA000000000002 /* DebouncedTaskModifier.swift */; };
+		AA00000CAAAA00000000000C /* CircularProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000003AAAA000000000003 /* CircularProgressView.swift */; };
+		AA00000DAAAA00000000000D /* AsyncButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000004AAAA000000000004 /* AsyncButton.swift */; };
+		AA00000EAAAA00000000000E /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000005AAAA000000000005 /* ImageLoader.swift */; };
+		AA00000FAAAA00000000000F /* CachedAsyncImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000006AAAA000000000006 /* CachedAsyncImage.swift */; };
+		AA000010AAAA000000000010 /* FuzzySearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000007AAAA000000000007 /* FuzzySearch.swift */; };
 		41062C992A3A263F00FD48EA /* UninstallSelfView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41062C982A3A263F00FD48EA /* UninstallSelfView.swift */; };
 		41062C9B2A3E4AFA00FD48EA /* Bundle+Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41062C9A2A3E4AFA00FD48EA /* Bundle+Version.swift */; };
 		411EDDD72A9F58180051E07B /* URL+QuotedPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411EDDD62A9F58180051E07B /* URL+QuotedPath.swift */; };
@@ -38,17 +45,17 @@
 		4126353E2A77C6EF00155034 /* Array+Chunked.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4126353D2A77C6EF00155034 /* Array+Chunked.swift */; };
 		412635442A77FB1600155034 /* BrewInstallationProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 412635432A77FB1600155034 /* BrewInstallationProgress.swift */; };
 		413E60B72BBAE5E000978F6A /* NetworkProxyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413E60B62BBAE5E000978F6A /* NetworkProxyManager.swift */; };
-		413E60C02BBF0E5C00978F6A /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 413E60BF2BBF0E5C00978F6A /* Kingfisher */; };
+
 		413E60C22BBFF98A00978F6A /* AppIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413E60C12BBFF98A00978F6A /* AppIconView.swift */; };
 		413F77A52972B2E70053349A /* DependencyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413F77A42972B2E70053349A /* DependencyManager.swift */; };
-		413F87242D32D2B100D4BE10 /* IfritStatic in Frameworks */ = {isa = PBXBuildFile; productRef = 413F87232D32D2B100D4BE10 /* IfritStatic */; };
+
 		413F87262D33048800D4BE10 /* InfoPopup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413F87252D33048800D4BE10 /* InfoPopup.swift */; };
 		413F87282D33DEAD00D4BE10 /* ContentView+SearchFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413F87272D33DEAD00D4BE10 /* ContentView+SearchFunctions.swift */; };
 		413F872C2D33E19800D4BE10 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413F872B2D33E19800D4BE10 /* HomeView.swift */; };
 		413F872E2D33E1CA00D4BE10 /* HomeView+NoSearchResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413F872D2D33E1CA00D4BE10 /* HomeView+NoSearchResults.swift */; };
 		413F87302D33E29A00D4BE10 /* HomeView+SortingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413F872F2D33E29A00D4BE10 /* HomeView+SortingOptions.swift */; };
 		413F87322D33E30400D4BE10 /* SortingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 413F87312D33E30400D4BE10 /* SortingOptions.swift */; };
-		413F87352D34109000D4BE10 /* ButtonKit in Frameworks */ = {isa = PBXBuildFile; productRef = 413F87342D34109000D4BE10 /* ButtonKit */; };
+
 		414074F528DF53E80073EB22 /* AppliteApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 414074F428DF53E80073EB22 /* AppliteApp.swift */; };
 		414074F728DF53E80073EB22 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 414074F628DF53E80073EB22 /* ContentView.swift */; };
 		414074F928DF53EB0073EB22 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 414074F828DF53EB0073EB22 /* Assets.xcassets */; };
@@ -72,8 +79,8 @@
 		41857B752912D94A004A1894 /* CategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41857B742912D94A004A1894 /* CategoryView.swift */; };
 		418989AD2A33A5C4004AC23B /* BrewManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418989AC2A33A5C4004AC23B /* BrewManagementView.swift */; };
 		418989AF2A33B65A004AC23B /* SmallProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418989AE2A33B65A004AC23B /* SmallProgressView.swift */; };
-		4189CE392937CD41009C836D /* Shimmer in Frameworks */ = {isa = PBXBuildFile; productRef = 4189CE382937CD41009C836D /* Shimmer */; };
-		418E9EF42AACD9C000046A58 /* CircularProgress in Frameworks */ = {isa = PBXBuildFile; productRef = 418E9EF32AACD9C000046A58 /* CircularProgress */; };
+
+
 		418F331C28EB3D540023D76F /* AppGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418F331B28EB3D540023D76F /* AppGridView.swift */; };
 		418F332428EC8BA10023D76F /* Cask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418F332328EC8BA10023D76F /* Cask.swift */; };
 		418F332628EC921D0023D76F /* CaskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418F332528EC921D0023D76F /* CaskManager.swift */; };
@@ -131,7 +138,7 @@
 		419256AB2D25E19B00D9EF10 /* BrewManagementView+ActionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419256AA2D25E19B00D9EF10 /* BrewManagementView+ActionsView.swift */; };
 		419256AD2D25E1F100D9EF10 /* BrewManagementView+InfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419256AC2D25E1F100D9EF10 /* BrewManagementView+InfoView.swift */; };
 		419256AF2D25F68700D9EF10 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419256AE2D25F68700D9EF10 /* AppDelegate.swift */; };
-		419256B22D26033400D9EF10 /* DebouncedOnChange in Frameworks */ = {isa = PBXBuildFile; productRef = 419256B12D26033400D9EF10 /* DebouncedOnChange */; };
+
 		419256B42D26B8A200D9EF10 /* CaskAdditionalInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419256B32D26B8A200D9EF10 /* CaskAdditionalInfo.swift */; };
 		419256B62D26BBBD00D9EF10 /* AppView+GetInfoButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419256B52D26BBBD00D9EF10 /* AppView+GetInfoButton.swift */; };
 		419256B92D26C02E00D9EF10 /* CaskInfoWindowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419256B82D26C02E00D9EF10 /* CaskInfoWindowView.swift */; };
@@ -221,6 +228,13 @@
 		415135692D32C48A0025DB70 /* Cask+Comparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Cask+Comparable.swift"; sourceTree = "<group>"; };
 		41524B98295E352200D0046A /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		415563A12A98BB2500AE2F2E /* ErrorWindowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorWindowView.swift; sourceTree = "<group>"; };
+		AA000001AAAA000000000001 /* ShimmerModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShimmerModifier.swift; sourceTree = "<group>"; };
+		AA000002AAAA000000000002 /* DebouncedTaskModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebouncedTaskModifier.swift; sourceTree = "<group>"; };
+		AA000003AAAA000000000003 /* CircularProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularProgressView.swift; sourceTree = "<group>"; };
+		AA000004AAAA000000000004 /* AsyncButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncButton.swift; sourceTree = "<group>"; };
+		AA000005AAAA000000000005 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
+		AA000006AAAA000000000006 /* CachedAsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedAsyncImage.swift; sourceTree = "<group>"; };
+		AA000007AAAA000000000007 /* FuzzySearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzySearch.swift; sourceTree = "<group>"; };
 		415563A32A98C54300AE2F2E /* AppdirSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppdirSelectorView.swift; sourceTree = "<group>"; };
 		415AA3F92E997A650065EF7C /* View+Modify.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Modify.swift"; sourceTree = "<group>"; };
 		4166EE6F28F5D4C900CE305A /* Commands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Commands.swift; sourceTree = "<group>"; };
@@ -313,13 +327,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				413F87352D34109000D4BE10 /* ButtonKit in Frameworks */,
 				41C8FA292A7A598B000BB9A2 /* Sparkle in Frameworks */,
-				419256B22D26033400D9EF10 /* DebouncedOnChange in Frameworks */,
-				4189CE392937CD41009C836D /* Shimmer in Frameworks */,
-				413F87242D32D2B100D4BE10 /* IfritStatic in Frameworks */,
-				418E9EF42AACD9C000046A58 /* CircularProgress in Frameworks */,
-				413E60C02BBF0E5C00978F6A /* Kingfisher in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -427,6 +435,10 @@
 				419256902D23F93E00D9EF10 /* Card.swift */,
 				4120AB662A755B0700F68EFE /* Sparkle Updater */,
 				413F87252D33048800D4BE10 /* InfoPopup.swift */,
+				AA000001AAAA000000000001 /* ShimmerModifier.swift */,
+				AA000002AAAA000000000002 /* DebouncedTaskModifier.swift */,
+				AA000003AAAA000000000003 /* CircularProgressView.swift */,
+				AA000004AAAA000000000004 /* AsyncButton.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -570,6 +582,23 @@
 			name = Packages;
 			sourceTree = "<group>";
 		};
+		AA000008AAAA000000000008 /* ImageLoader */ = {
+			isa = PBXGroup;
+			children = (
+				AA000005AAAA000000000005 /* ImageLoader.swift */,
+				AA000006AAAA000000000006 /* CachedAsyncImage.swift */,
+			);
+			path = ImageLoader;
+			sourceTree = "<group>";
+		};
+		AA000009AAAA000000000009 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				AA000007AAAA000000000007 /* FuzzySearch.swift */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
 		4191393129269FD600F1D75D /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
@@ -581,6 +610,8 @@
 				4101EB532DCE7F7F00BE0670 /* Mirror */,
 				419256652D1E18A500D9EF10 /* Alert Manager */,
 				419256102D1DDB9700D9EF10 /* Other */,
+				AA000008AAAA000000000008 /* ImageLoader */,
+				AA000009AAAA000000000009 /* Search */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -818,13 +849,7 @@
 			);
 			name = Applite;
 			packageProductDependencies = (
-				4189CE382937CD41009C836D /* Shimmer */,
 				41C8FA282A7A598B000BB9A2 /* Sparkle */,
-				418E9EF32AACD9C000046A58 /* CircularProgress */,
-				413E60BF2BBF0E5C00978F6A /* Kingfisher */,
-				419256B12D26033400D9EF10 /* DebouncedOnChange */,
-				413F87232D32D2B100D4BE10 /* IfritStatic */,
-				413F87342D34109000D4BE10 /* ButtonKit */,
 			);
 			productName = Applite;
 			productReference = 414074F128DF53E80073EB22 /* Applite.app */;
@@ -859,13 +884,7 @@
 			);
 			mainGroup = 414074E828DF53E80073EB22;
 			packageReferences = (
-				4189CE372937CD41009C836D /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */,
 				41C8FA272A7A598B000BB9A2 /* XCRemoteSwiftPackageReference "Sparkle" */,
-				418E9EF22AACD9C000046A58 /* XCRemoteSwiftPackageReference "CircularProgressSwiftUI" */,
-				413E60BE2BBF0E5C00978F6A /* XCRemoteSwiftPackageReference "Kingfisher" */,
-				419256B02D26033400D9EF10 /* XCRemoteSwiftPackageReference "DebouncedOnChange" */,
-				413F87222D32D2B100D4BE10 /* XCRemoteSwiftPackageReference "Ifrit" */,
-				413F87332D34109000D4BE10 /* XCRemoteSwiftPackageReference "ButtonKit" */,
 			);
 			productRefGroup = 414074F228DF53E80073EB22 /* Products */;
 			projectDirPath = "";
@@ -897,6 +916,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA00000AAAAA00000000000A /* ShimmerModifier.swift in Sources */,
+				AA00000BAAAA00000000000B /* DebouncedTaskModifier.swift in Sources */,
+				AA00000CAAAA00000000000C /* CircularProgressView.swift in Sources */,
+				AA00000DAAAA00000000000D /* AsyncButton.swift in Sources */,
+				AA00000EAAAA00000000000E /* ImageLoader.swift in Sources */,
+				AA00000FAAAA00000000000F /* CachedAsyncImage.swift in Sources */,
+				AA000010AAAA000000000010 /* FuzzySearch.swift in Sources */,
 				5CDD639E54F54A68FEC0B100 /* ICloudSyncManager.swift in Sources */,
 				95F476538772FD39D3F5E464 /* AppHistoryView.swift in Sources */,
 				413F87322D33E30400D4BE10 /* SortingOptions.swift in Sources */,
@@ -1248,54 +1274,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		413E60BE2BBF0E5C00978F6A /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/onevcat/Kingfisher";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 8.1.0;
-			};
-		};
-		413F87222D32D2B100D4BE10 /* XCRemoteSwiftPackageReference "Ifrit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/ukushu/Ifrit";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 3.0.0;
-			};
-		};
-		413F87332D34109000D4BE10 /* XCRemoteSwiftPackageReference "ButtonKit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Dean151/ButtonKit";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.6.1;
-			};
-		};
-		4189CE372937CD41009C836D /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/markiv/SwiftUI-Shimmer";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
-			};
-		};
-		418E9EF22AACD9C000046A58 /* XCRemoteSwiftPackageReference "CircularProgressSwiftUI" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/ArnavMotwani/CircularProgressSwiftUI";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.2.1;
-			};
-		};
-		419256B02D26033400D9EF10 /* XCRemoteSwiftPackageReference "DebouncedOnChange" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Tunous/DebouncedOnChange";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
-			};
-		};
 		41C8FA272A7A598B000BB9A2 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
@@ -1307,36 +1285,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		413E60BF2BBF0E5C00978F6A /* Kingfisher */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 413E60BE2BBF0E5C00978F6A /* XCRemoteSwiftPackageReference "Kingfisher" */;
-			productName = Kingfisher;
-		};
-		413F87232D32D2B100D4BE10 /* IfritStatic */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 413F87222D32D2B100D4BE10 /* XCRemoteSwiftPackageReference "Ifrit" */;
-			productName = IfritStatic;
-		};
-		413F87342D34109000D4BE10 /* ButtonKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 413F87332D34109000D4BE10 /* XCRemoteSwiftPackageReference "ButtonKit" */;
-			productName = ButtonKit;
-		};
-		4189CE382937CD41009C836D /* Shimmer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 4189CE372937CD41009C836D /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */;
-			productName = Shimmer;
-		};
-		418E9EF32AACD9C000046A58 /* CircularProgress */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 418E9EF22AACD9C000046A58 /* XCRemoteSwiftPackageReference "CircularProgressSwiftUI" */;
-			productName = CircularProgress;
-		};
-		419256B12D26033400D9EF10 /* DebouncedOnChange */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 419256B02D26033400D9EF10 /* XCRemoteSwiftPackageReference "DebouncedOnChange" */;
-			productName = DebouncedOnChange;
-		};
 		41C8FA282A7A598B000BB9A2 /* Sparkle */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 41C8FA272A7A598B000BB9A2 /* XCRemoteSwiftPackageReference "Sparkle" */;

--- a/Applite/Applite.entitlements
+++ b/Applite/Applite.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
 </dict>
 </plist>

--- a/Applite/AppliteApp.swift
+++ b/Applite/AppliteApp.swift
@@ -15,6 +15,7 @@ struct AppliteApp: App {
     @NSApplicationDelegateAdaptor(ApplicationDelegate.self) var appDelegate
 
     @StateObject var caskManager = CaskManager()
+    @StateObject var iCloudSyncManager = ICloudSyncManager()
     
     @AppStorage(Preferences.colorSchemePreference.rawValue) var colorSchemePreference: ColorSchemePreference = .system
     @AppStorage(Preferences.setupComplete.rawValue) var setupComplete: Bool = false
@@ -45,6 +46,7 @@ struct AppliteApp: App {
             if setupComplete {
                 ContentView()
                     .environmentObject(caskManager)
+                    .environmentObject(iCloudSyncManager)
                     .frame(minWidth: 970, minHeight: 520)
                     .preferredColorScheme(selectedColorScheme)
             } else {
@@ -60,6 +62,7 @@ struct AppliteApp: App {
         
         Settings {
             SettingsView(updater: updaterController.updater)
+                .environmentObject(iCloudSyncManager)
                 .preferredColorScheme(selectedColorScheme)
         }
         .windowResizability(.contentSize)

--- a/Applite/AppliteApp.swift
+++ b/Applite/AppliteApp.swift
@@ -8,7 +8,6 @@
 import Foundation
 import SwiftUI
 import Sparkle
-import Kingfisher
 
 @main
 struct AppliteApp: App {
@@ -36,9 +35,6 @@ struct AppliteApp: App {
     
     init() {
         updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
-
-        // Setup network proxy for Kingfisher
-        KingfisherManager.shared.downloader.sessionConfiguration = NetworkProxyManager.getURLSessionConfiguration()
     }
     
     var body: some Scene {

--- a/Applite/AppliteDebug.entitlements
+++ b/Applite/AppliteDebug.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
 </dict>
 </plist>

--- a/Applite/Model/Cask Models/Cask Manager/CaskManager+BrewFunctions.swift
+++ b/Applite/Model/Cask Models/Cask Manager/CaskManager+BrewFunctions.swift
@@ -88,6 +88,9 @@ extension CaskManager {
             // Update state
             cask.isInstalled = true
             self.installedCasks.addCask(cask)
+
+            // Sync to iCloud history
+            self.iCloudSyncManager?.addCask(cask.id)
         }
     }
 

--- a/Applite/Model/Cask Models/Cask Manager/CaskManager.swift
+++ b/Applite/Model/Cask Models/Cask Manager/CaskManager.swift
@@ -26,6 +26,9 @@ final class CaskManager: ObservableObject {
     /// The data coordinator that orchestrates data loading
     lazy var dataCoordinator = CaskDataCoordinator()
 
+    /// iCloud sync manager, set by AppliteApp after init
+    weak var iCloudSyncManager: ICloudSyncManager?
+
     // Searchble cask collections
     let allCasks = SearchableCaskCollection()
     let installedCasks = SearchableCaskCollection()

--- a/Applite/Model/Cask Models/Cask/Cask+Searchable.swift
+++ b/Applite/Model/Cask Models/Cask/Cask+Searchable.swift
@@ -6,14 +6,13 @@
 //
 
 import Foundation
-import Ifrit
 
-extension Cask: Searchable {
-    nonisolated var weightedSearchProperties: [FuseProp] {
+extension Cask: FuzzySearchable {
+    nonisolated var searchProperties: [FuzzySearchProperty] {
         return [
-            FuseProp(self.info.name, weight: 1),
-            FuseProp(self.info.token, weight: 1),
-            FuseProp(self.info.description, weight: 0.3)
+            FuzzySearchProperty(self.info.name, weight: 1),
+            FuzzySearchProperty(self.info.token, weight: 1),
+            FuzzySearchProperty(self.info.description, weight: 0.3)
         ]
     }
 }

--- a/Applite/Model/Cask Models/View Models/SearchableCaskCollection.swift
+++ b/Applite/Model/Cask Models/View Models/SearchableCaskCollection.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Ifrit
 
 @MainActor
 class SearchableCaskCollection: ObservableObject {
@@ -42,13 +41,12 @@ class SearchableCaskCollection: ObservableObject {
             return
         }
 
-        let fuse = Fuse()
-        let searchResults = await fuse.search(query, in: self.casks, by: \Cask.weightedSearchProperties)
+        let searchResults = await FuzzySearch.search(query, in: self.casks, by: \Cask.searchProperties)
 
         var matchedCasks: [Cask] = []
 
         for result in searchResults {
-            guard result.diffScore <= diffScroreThreshold else {
+            guard result.score <= diffScroreThreshold else {
                 break
             }
 

--- a/Applite/Model/Preferences/Preferences.swift
+++ b/Applite/Model/Preferences/Preferences.swift
@@ -37,6 +37,9 @@ enum Preferences: String {
     case mirrorCoreGitRemote
     case mirrorBottleDomain
 
+    // iCloud
+    case iCloudSyncEnabled
+
     // Sorting options
     case searchSortOption
     case hideUnpopularApps

--- a/Applite/Model/SidebarItem.swift
+++ b/Applite/Model/SidebarItem.swift
@@ -12,6 +12,7 @@ enum SidebarItem: Equatable, Hashable {
     case updates
     case installed
     case activeTasks
+    case appHistory
     case appMigration
     case brew
     case appCategory(category: CategoryViewModel)

--- a/Applite/Utilities/ICloudSyncManager.swift
+++ b/Applite/Utilities/ICloudSyncManager.swift
@@ -1,0 +1,118 @@
+//
+//  ICloudSyncManager.swift
+//  Applite
+//
+//  Created on 2026.02.09.
+//
+
+import Foundation
+import OSLog
+
+/// Manages iCloud Key-Value Store sync for previously installed cask IDs
+@MainActor
+final class ICloudSyncManager: ObservableObject {
+    @Published private(set) var previouslyInstalledCaskIds: Set<CaskId> = []
+
+    private let store = NSUbiquitousKeyValueStore.default
+    private static let storeKey = "previouslyInstalledCasks"
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier!,
+        category: String(describing: ICloudSyncManager.self)
+    )
+
+    init() {
+        loadFromStore()
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(storeDidChangeExternally(_:)),
+            name: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
+            object: store
+        )
+
+        store.synchronize()
+    }
+
+    // MARK: - Public methods
+
+    func addCask(_ id: CaskId) {
+        guard isEnabled else { return }
+        guard !previouslyInstalledCaskIds.contains(id) else { return }
+
+        previouslyInstalledCaskIds.insert(id)
+        saveToStore()
+        Self.logger.info("Added cask '\(id)' to app history")
+    }
+
+    func addCasks(_ ids: Set<CaskId>) {
+        guard isEnabled else { return }
+        let newIds = ids.subtracting(previouslyInstalledCaskIds)
+        guard !newIds.isEmpty else { return }
+
+        previouslyInstalledCaskIds.formUnion(newIds)
+        saveToStore()
+        Self.logger.info("Added \(newIds.count) cask(s) to app history")
+    }
+
+    func removeCask(_ id: CaskId) {
+        previouslyInstalledCaskIds.remove(id)
+        saveToStore()
+        Self.logger.info("Removed cask '\(id)' from app history")
+    }
+
+    func clearAll() {
+        previouslyInstalledCaskIds.removeAll()
+        store.removeObject(forKey: Self.storeKey)
+        store.synchronize()
+        Self.logger.info("Cleared all app history")
+    }
+
+    // MARK: - Private
+
+    private var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: Preferences.iCloudSyncEnabled.rawValue)
+    }
+
+    private func loadFromStore() {
+        guard let data = store.data(forKey: Self.storeKey) else { return }
+
+        do {
+            let ids = try JSONDecoder().decode([String].self, from: data)
+            previouslyInstalledCaskIds = Set(ids)
+            Self.logger.info("Loaded \(ids.count) cask(s) from iCloud KVS")
+        } catch {
+            Self.logger.error("Failed to decode iCloud KVS data: \(error.localizedDescription)")
+        }
+    }
+
+    private func saveToStore() {
+        do {
+            let data = try JSONEncoder().encode(Array(previouslyInstalledCaskIds))
+            store.set(data, forKey: Self.storeKey)
+            store.synchronize()
+        } catch {
+            Self.logger.error("Failed to encode iCloud KVS data: \(error.localizedDescription)")
+        }
+    }
+
+    @objc
+    nonisolated private func storeDidChangeExternally(_ notification: Notification) {
+        Task { @MainActor in
+            Self.logger.info("Received external iCloud KVS change")
+
+            guard let data = store.data(forKey: Self.storeKey) else { return }
+
+            do {
+                let remoteIds = try JSONDecoder().decode([String].self, from: data)
+                let remoteSet = Set(remoteIds)
+                // Union merge — never lose installs from either side
+                previouslyInstalledCaskIds.formUnion(remoteSet)
+                saveToStore()
+                Self.logger.info("Merged external changes, total: \(self.previouslyInstalledCaskIds.count) cask(s)")
+            } catch {
+                Self.logger.error("Failed to decode external iCloud KVS data: \(error.localizedDescription)")
+            }
+        }
+    }
+}

--- a/Applite/Utilities/ImageLoader/CachedAsyncImage.swift
+++ b/Applite/Utilities/ImageLoader/CachedAsyncImage.swift
@@ -1,0 +1,49 @@
+//
+//  CachedAsyncImage.swift
+//  Applite
+//
+//  Created by Milán Várady on 2025.
+//
+
+import SwiftUI
+
+/// A SwiftUI view that loads and caches images asynchronously with proxy support
+struct CachedAsyncImage<Placeholder: View>: View {
+    let url: URL
+    let cacheKey: String
+    var onFailure: (() -> Void)?
+    @ViewBuilder let placeholder: () -> Placeholder
+
+    @State private var image: NSImage?
+    @State private var loadFailed = false
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(nsImage: image)
+                    .resizable()
+                    .transition(.opacity)
+            } else {
+                placeholder()
+            }
+        }
+        .animation(.easeIn(duration: 0.25), value: image != nil)
+        .task(id: url) {
+            do {
+                let loaded = try await ImageLoader.shared.loadImage(from: url, cacheKey: cacheKey)
+                self.image = loaded
+            } catch {
+                loadFailed = true
+                onFailure?()
+            }
+        }
+    }
+}
+
+extension CachedAsyncImage {
+    func onFailure(_ handler: @escaping () -> Void) -> CachedAsyncImage {
+        var copy = self
+        copy.onFailure = handler
+        return copy
+    }
+}

--- a/Applite/Utilities/ImageLoader/ImageLoader.swift
+++ b/Applite/Utilities/ImageLoader/ImageLoader.swift
@@ -1,0 +1,67 @@
+//
+//  ImageLoader.swift
+//  Applite
+//
+//  Created by Milán Várady on 2025.
+//
+
+import Foundation
+import AppKit
+import OSLog
+
+/// Singleton actor that handles image downloading and caching with proxy support
+actor ImageLoader {
+    static let shared = ImageLoader()
+
+    private let session: URLSession
+    private let memoryCache = NSCache<NSString, NSImage>()
+    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "ImageLoader")
+
+    private init() {
+        let config = NetworkProxyManager.getURLSessionConfiguration()
+        config.urlCache = URLCache(
+            memoryCapacity: 50 * 1024 * 1024,  // 50 MB memory
+            diskCapacity: 200 * 1024 * 1024,    // 200 MB disk
+            diskPath: "dev.aerolite.Applite.ImageCache"
+        )
+        self.session = URLSession(configuration: config)
+        memoryCache.countLimit = 500
+    }
+
+    func loadImage(from url: URL, cacheKey: String) async throws -> NSImage {
+        let key = cacheKey as NSString
+
+        // Check memory cache first
+        if let cached = memoryCache.object(forKey: key) {
+            return cached
+        }
+
+        // Download
+        let (data, _) = try await session.data(from: url)
+
+        guard let image = NSImage(data: data) else {
+            throw ImageLoaderError.invalidImageData
+        }
+
+        // Store in memory cache
+        memoryCache.setObject(image, forKey: key)
+
+        return image
+    }
+
+    func clearCache() {
+        memoryCache.removeAllObjects()
+        session.configuration.urlCache?.removeAllCachedResponses()
+    }
+}
+
+enum ImageLoaderError: LocalizedError {
+    case invalidImageData
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidImageData:
+            return "Failed to decode image data"
+        }
+    }
+}

--- a/Applite/Utilities/Other/UninstallSelf.swift
+++ b/Applite/Utilities/Other/UninstallSelf.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import OSLog
-import Kingfisher
 
 /// This function will uninstall Applite and all it's related files
 func uninstallSelf(deleteBrewCache: Bool, uninstallHomebrew: Bool = false) async throws {
@@ -15,13 +14,9 @@ func uninstallSelf(deleteBrewCache: Bool, uninstallHomebrew: Bool = false) async
     
     logger.notice("Applite uninstallation stated. deleteBrewCache: \(deleteBrewCache), uninstallHomebrew: \(uninstallHomebrew)")
 
-    logger.notice("Clearing Kingfisher image cache")
-
-    let cache = ImageCache.default
-    cache.clearMemoryCache()
-    cache.clearDiskCache {
-        logger.notice("Kingfisher disk image cache cleared")
-    }
+    logger.notice("Clearing image cache")
+    await ImageLoader.shared.clearCache()
+    logger.notice("Image cache cleared")
 
     logger.notice("Deleting library files")
 

--- a/Applite/Utilities/Search/FuzzySearch.swift
+++ b/Applite/Utilities/Search/FuzzySearch.swift
@@ -1,0 +1,130 @@
+//
+//  FuzzySearch.swift
+//  Applite
+//
+//  Created by Milán Várady on 2025.
+//
+
+import Foundation
+
+/// A weighted search property for fuzzy matching
+struct FuzzySearchProperty: Sendable {
+    let text: String
+    let weight: Double
+
+    init(_ text: String, weight: Double = 1.0) {
+        self.text = text
+        self.weight = weight
+    }
+}
+
+/// Protocol for types that can be fuzzy searched
+protocol FuzzySearchable {
+    var searchProperties: [FuzzySearchProperty] { get }
+}
+
+/// Result of a fuzzy search operation
+struct FuzzySearchResult {
+    let index: Int
+    let score: Double
+}
+
+/// Performs fuzzy search on a collection of items
+enum FuzzySearch {
+    /// Search for a query in a collection, returning results sorted by score (lower is better match)
+    static func search<T>(
+        _ query: String,
+        in items: [T],
+        by keyPath: KeyPath<T, [FuzzySearchProperty]>
+    ) async -> [FuzzySearchResult] {
+        let lowercasedQuery = query.lowercased()
+
+        var results: [FuzzySearchResult] = []
+
+        for (index, item) in items.enumerated() {
+            let properties = item[keyPath: keyPath]
+            var bestScore = Double.infinity
+
+            for property in properties {
+                let text = property.text.lowercased()
+                let weight = property.weight
+                let score = computeScore(query: lowercasedQuery, text: text)
+
+                if score < Double.infinity {
+                    let weightedScore = score / weight
+                    bestScore = min(bestScore, weightedScore)
+                }
+            }
+
+            if bestScore < Double.infinity {
+                results.append(FuzzySearchResult(index: index, score: bestScore))
+            }
+        }
+
+        results.sort { $0.score < $1.score }
+        return results
+    }
+
+    /// Compute a fuzzy match score between query and text.
+    /// Returns Double.infinity for no match. Lower scores = better match.
+    /// Score is normalized to 0...1 range for matches.
+    private static func computeScore(query: String, text: String) -> Double {
+        if query.isEmpty { return 0 }
+        if text.isEmpty { return .infinity }
+
+        // Exact match
+        if text == query { return 0 }
+
+        // Prefix match
+        if text.hasPrefix(query) {
+            return 0.01
+        }
+
+        // Contains as substring
+        if text.contains(query) {
+            return 0.05
+        }
+
+        // Fuzzy character-by-character matching
+        let queryChars = Array(query)
+        let textChars = Array(text)
+
+        var queryIndex = 0
+        var lastMatchIndex = -1
+        var totalGap = 0
+        var consecutiveMatches = 0
+        var maxConsecutive = 0
+
+        for (textIndex, textChar) in textChars.enumerated() {
+            guard queryIndex < queryChars.count else { break }
+
+            if textChar == queryChars[queryIndex] {
+                if lastMatchIndex >= 0 {
+                    let gap = textIndex - lastMatchIndex - 1
+                    totalGap += gap
+                    if gap == 0 {
+                        consecutiveMatches += 1
+                        maxConsecutive = max(maxConsecutive, consecutiveMatches)
+                    } else {
+                        consecutiveMatches = 0
+                    }
+                }
+                lastMatchIndex = textIndex
+                queryIndex += 1
+            }
+        }
+
+        // Not all query characters found
+        guard queryIndex == queryChars.count else {
+            return .infinity
+        }
+
+        // Compute score: penalize gaps, reward consecutive matches
+        let gapPenalty = Double(totalGap) / Double(textChars.count)
+        let consecutiveBonus = Double(maxConsecutive) / Double(queryChars.count)
+        let lengthPenalty = Double(textChars.count - queryChars.count) / Double(textChars.count)
+
+        let score = 0.1 + gapPenalty * 0.4 + lengthPenalty * 0.3 - consecutiveBonus * 0.2
+        return min(max(score, 0.06), 1.0)
+    }
+}

--- a/Applite/Views/App Views/App View/AppView+ActionsView.swift
+++ b/Applite/Views/App Views/App View/AppView+ActionsView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import CircularProgress
 
 extension AppView {
     @ViewBuilder
@@ -61,15 +60,8 @@ extension AppView {
             .scaleEffect(0.8)
 
         case .downloading(let percent):
-            CircularProgressView(
-                count: Int(percent * 100),
-                total: 100,
-                progress: CGFloat(percent),
-                fontOne: .system(size: 14, weight: .black),
-                lineWidth: 4,
-                showBottomText: false
-            )
-            .frame(width: 36, height: 36)
+            CircularProgressView(progress: percent, lineWidth: 4)
+                .frame(width: 36, height: 36)
 
         case .success:
             Image(systemName: "checkmark")

--- a/Applite/Views/App Views/App View/AppView+GetInfoButton.swift
+++ b/Applite/Views/App Views/App View/AppView+GetInfoButton.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import ButtonKit
 import OSLog
 
 extension AppView {

--- a/Applite/Views/App Views/App View/AppView+OpenAndManageView.swift
+++ b/Applite/Views/App Views/App View/AppView+OpenAndManageView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import ButtonKit
 
 extension AppView {
     /// Button used in the Download section, launches, uninstalls or reinstalls the app
@@ -26,13 +25,13 @@ extension AppView {
             AsyncButton("Open") {
                 try await cask.launchApp()
             }
-            .font(.system(size: 14))
-            .buttonStyle(.bordered)
-            .clipShape(Capsule())
             .onButtonError { error in
                 showAppNotFoundAlert = true
             }
             .asyncButtonStyle(.none)
+            .font(.system(size: 14))
+            .buttonStyle(.bordered)
+            .clipShape(Capsule())
             .alert("Applite couldn't open \(cask.info.name)", isPresented: $showAppNotFoundAlert) {}
 
             if deleteButton {

--- a/Applite/Views/App Views/AppIconView.swift
+++ b/Applite/Views/App Views/AppIconView.swift
@@ -6,8 +6,6 @@
 //
 
 import SwiftUI
-import Kingfisher
-import Shimmer
 
 enum AppIconState {
     case showingAppIcon
@@ -24,27 +22,26 @@ struct AppIconView: View {
 
     var body: some View {
         if state != .failed {
-            KFImage.url(state == .showingAppIcon ? iconURL : faviconURL, cacheKey: cacheKey)
-                .resizable()
-                .placeholder {
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .fill(.gray)
-                        .shimmering()
+            CachedAsyncImage(
+                url: state == .showingAppIcon ? iconURL : faviconURL,
+                cacheKey: cacheKey
+            ) {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(.gray)
+                    .shimmering()
+            }
+            .onFailure {
+                switch state {
+                case .showingAppIcon:
+                    state = .showingFavicon
+                case .showingFavicon:
+                    state = .failed
+                default:
+                    state = .failed
                 }
-                .setProcessor(RoundCornerImageProcessor(cornerRadius: 8)) // Round corners
-                .fade(duration: 0.25)
-                .onFailure { error in
-                    // Change state
-                    switch state {
-                    case .showingAppIcon:
-                        state = .showingFavicon
-                    case .showingFavicon:
-                        state = .failed
-                    default:
-                        state = .failed
-                    }
-                }
-                .frame(width: 54, height: 54)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .frame(width: 54, height: 54)
         } else {
             // App icon missing
             ZStack {

--- a/Applite/Views/Components/AsyncButton.swift
+++ b/Applite/Views/Components/AsyncButton.swift
@@ -1,0 +1,95 @@
+//
+//  AsyncButton.swift
+//  Applite
+//
+//  Created by Milán Várady on 2025.
+//
+
+import SwiftUI
+
+enum AsyncButtonStyle {
+    /// Shows a ProgressView overlay while running
+    case `default`
+    /// Shows a ProgressView after the label
+    case trailing
+    /// No visual indicator, just disables the button
+    case none
+}
+
+struct AsyncButton<Label: View>: View {
+    var action: () async throws -> Void
+    var errorHandler: ((Error) -> Void)?
+    var style: AsyncButtonStyle = .default
+    @ViewBuilder var label: () -> Label
+
+    @State private var isRunning = false
+
+    var body: some View {
+        Button {
+            isRunning = true
+            Task {
+                do {
+                    try await action()
+                } catch {
+                    errorHandler?(error)
+                }
+                isRunning = false
+            }
+        } label: {
+            switch style {
+            case .default:
+                label()
+                    .opacity(isRunning ? 0 : 1)
+                    .overlay {
+                        if isRunning {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                    }
+            case .trailing:
+                HStack(spacing: 6) {
+                    label()
+                    if isRunning {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                }
+            case .none:
+                label()
+            }
+        }
+        .disabled(isRunning)
+    }
+}
+
+// MARK: - Convenience Initializers
+
+extension AsyncButton where Label == SwiftUI.Label<Text, Image> {
+    init(_ title: String, systemImage: String, action: @escaping () async throws -> Void) {
+        self.action = action
+        self.label = { SwiftUI.Label(title, systemImage: systemImage) }
+    }
+}
+
+extension AsyncButton where Label == Text {
+    init(_ title: String, action: @escaping () async throws -> Void) {
+        self.action = action
+        self.label = { Text(title) }
+    }
+}
+
+// MARK: - Modifiers
+
+extension AsyncButton {
+    func onButtonError(_ handler: @escaping (Error) -> Void) -> AsyncButton {
+        var copy = self
+        copy.errorHandler = handler
+        return copy
+    }
+
+    func asyncButtonStyle(_ style: AsyncButtonStyle) -> AsyncButton {
+        var copy = self
+        copy.style = style
+        return copy
+    }
+}

--- a/Applite/Views/Components/Brew Path Selector/BrewPathSelectorView.swift
+++ b/Applite/Views/Components/Brew Path Selector/BrewPathSelectorView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import DebouncedOnChange
 
 /// Provides a picker so the user can select the brew executable path they want to use
 struct BrewPathSelectorView: View {

--- a/Applite/Views/Components/CircularProgressView.swift
+++ b/Applite/Views/Components/CircularProgressView.swift
@@ -1,0 +1,35 @@
+//
+//  CircularProgressView.swift
+//  Applite
+//
+//  Created by Milán Várady on 2025.
+//
+
+import SwiftUI
+
+/// A circular progress indicator that displays a percentage
+struct CircularProgressView: View {
+    let progress: Double
+    var lineWidth: CGFloat = 4
+    var font: Font = .system(size: 14, weight: .black)
+
+    var body: some View {
+        ZStack {
+            // Background track
+            Circle()
+                .stroke(.gray.opacity(0.3), lineWidth: lineWidth)
+
+            // Progress arc
+            Circle()
+                .trim(from: 0, to: CGFloat(progress))
+                .stroke(style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+                .foregroundStyle(.tint)
+                .rotationEffect(.degrees(-90))
+                .animation(.linear, value: progress)
+
+            // Percentage text
+            Text("\(Int(progress * 100))%")
+                .font(font)
+        }
+    }
+}

--- a/Applite/Views/Components/DebouncedTaskModifier.swift
+++ b/Applite/Views/Components/DebouncedTaskModifier.swift
@@ -1,0 +1,46 @@
+//
+//  DebouncedTaskModifier.swift
+//  Applite
+//
+//  Created by Milán Várady on 2025.
+//
+
+import SwiftUI
+
+extension View {
+    /// A debounced version of `.task(id:)` that delays the action execution.
+    /// When `id` changes, SwiftUI cancels the previous task (cancelling the sleep),
+    /// providing natural debouncing.
+    func task<T: Equatable>(id: T, debounceTime: Duration, @_inheritActorContext action: @escaping @Sendable () async -> Void) -> some View {
+        self.task(id: id) {
+            try? await Task.sleep(for: debounceTime)
+            guard !Task.isCancelled else { return }
+            await action()
+        }
+    }
+
+    /// A debounced version of `.onChange(of:)` that delays the action execution.
+    func onChange<T: Equatable>(of value: T, debounceTime: Duration, action: @escaping (_ newValue: T) -> Void) -> some View {
+        self.modifier(DebouncedOnChangeModifier(value: value, debounceTime: debounceTime, action: action))
+    }
+}
+
+private struct DebouncedOnChangeModifier<T: Equatable>: ViewModifier {
+    let value: T
+    let debounceTime: Duration
+    let action: (T) -> Void
+
+    @State private var debounceTask: Task<Void, Never>?
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: value) { newValue in
+                debounceTask?.cancel()
+                debounceTask = Task {
+                    try? await Task.sleep(for: debounceTime)
+                    guard !Task.isCancelled else { return }
+                    action(newValue)
+                }
+            }
+    }
+}

--- a/Applite/Views/Components/ShimmerModifier.swift
+++ b/Applite/Views/Components/ShimmerModifier.swift
@@ -1,0 +1,44 @@
+//
+//  ShimmerModifier.swift
+//  Applite
+//
+//  Created by Milán Várady on 2025.
+//
+
+import SwiftUI
+
+/// A view modifier that adds a shimmering animation effect
+struct ShimmerModifier: ViewModifier {
+    @State private var phase: CGFloat = 0
+
+    func body(content: Content) -> some View {
+        content
+            .overlay(
+                GeometryReader { geometry in
+                    LinearGradient(
+                        gradient: Gradient(colors: [
+                            .clear,
+                            .white.opacity(0.4),
+                            .clear
+                        ]),
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                    .frame(width: geometry.size.width * 2)
+                    .offset(x: -geometry.size.width + phase * geometry.size.width * 3)
+                }
+            )
+            .clipped()
+            .onAppear {
+                withAnimation(.linear(duration: 1.5).repeatForever(autoreverses: false)) {
+                    phase = 1
+                }
+            }
+    }
+}
+
+extension View {
+    func shimmering() -> some View {
+        modifier(ShimmerModifier())
+    }
+}

--- a/Applite/Views/Content View/ContentView+DetailView.swift
+++ b/Applite/Views/Content View/ContentView+DetailView.swift
@@ -32,7 +32,10 @@ extension ContentView {
             
         case .activeTasks:
             ActiveTasksView()
-            
+
+        case .appHistory:
+            AppHistoryView()
+
         case .appMigration:
             AppMigrationView()
             

--- a/Applite/Views/Content View/ContentView+DetailView.swift
+++ b/Applite/Views/Content View/ContentView+DetailView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import ButtonKit
 
 extension ContentView {
     @ViewBuilder

--- a/Applite/Views/Content View/ContentView+LoadCasks.swift
+++ b/Applite/Views/Content View/ContentView+LoadCasks.swift
@@ -29,6 +29,10 @@ extension ContentView {
         do {
             try await caskManager.loadData()
             brokenInstall = false
+
+            // Sync currently installed cask IDs to iCloud
+            let installedIds = Set(caskManager.installedCasks.casks.map(\.id))
+            iCloudSyncManager.addCasks(installedIds)
         } catch {
             loadAlert.show(title: "Couldn't load app catalog", message: error.localizedDescription)
             logger.error("Initial cask load failure. Reason: \(error.localizedDescription)")

--- a/Applite/Views/Content View/ContentView+SidebarViews.swift
+++ b/Applite/Views/Content View/ContentView+SidebarViews.swift
@@ -74,17 +74,16 @@ extension ContentView {
         @AppStorage(Preferences.iCloudSyncEnabled.rawValue) var iCloudSyncEnabled: Bool = false
 
         private var notInstalledCount: Int {
-            iCloudSyncManager.previouslyInstalledCaskIds.filter { id in
+            guard iCloudSyncEnabled else { return 0 }
+            return iCloudSyncManager.previouslyInstalledCaskIds.filter { id in
                 caskManager.casks[id]?.isInstalled != true
             }.count
         }
 
         var body: some View {
-            if iCloudSyncEnabled && notInstalledCount > 0 {
-                Label("App History", systemImage: "clock.arrow.circlepath")
-                    .badge(notInstalledCount)
-                    .tag(SidebarItem.appHistory)
-            }
+            Label("App History", systemImage: "clock.arrow.circlepath")
+                .badge(notInstalledCount)
+                .tag(SidebarItem.appHistory)
         }
     }
 }

--- a/Applite/Views/Content View/ContentView+SidebarViews.swift
+++ b/Applite/Views/Content View/ContentView+SidebarViews.swift
@@ -25,6 +25,11 @@ extension ContentView {
                 .badge(caskManager.activeTasks.count)
                 .tag(SidebarItem.activeTasks)
 
+            AppHistorySidebarItem(
+                iCloudSyncManager: iCloudSyncManager,
+                caskManager: caskManager
+            )
+
             Label("App Migration", systemImage: "square.and.arrow.up.on.square")
                 .tag(SidebarItem.appMigration)
 
@@ -59,6 +64,27 @@ extension ContentView {
         var body: some View {
             Label("Updates", systemImage: "arrow.clockwise.circle.fill")
                 .badge(caskCollection.casks.count)
+        }
+    }
+
+    // Extracted so badge reacts to changes in iCloudSyncManager and caskManager
+    struct AppHistorySidebarItem: View {
+        @ObservedObject var iCloudSyncManager: ICloudSyncManager
+        @ObservedObject var caskManager: CaskManager
+        @AppStorage(Preferences.iCloudSyncEnabled.rawValue) var iCloudSyncEnabled: Bool = false
+
+        private var notInstalledCount: Int {
+            iCloudSyncManager.previouslyInstalledCaskIds.filter { id in
+                caskManager.casks[id]?.isInstalled != true
+            }.count
+        }
+
+        var body: some View {
+            if iCloudSyncEnabled && notInstalledCount > 0 {
+                Label("App History", systemImage: "clock.arrow.circlepath")
+                    .badge(notInstalledCount)
+                    .tag(SidebarItem.appHistory)
+            }
         }
     }
 }

--- a/Applite/Views/Content View/ContentView.swift
+++ b/Applite/Views/Content View/ContentView.swift
@@ -11,7 +11,8 @@ import ButtonKit
 
 struct ContentView: View {
     @EnvironmentObject var caskManager: CaskManager
-    
+    @EnvironmentObject var iCloudSyncManager: ICloudSyncManager
+
     /// Currently selected tab in the sidebar
     @State var selection: SidebarItem = .home
 
@@ -39,6 +40,9 @@ struct ContentView: View {
                 .disabled(modifyingBrew)
         } detail: {
             detailView
+        }
+        .onAppear {
+            caskManager.iCloudSyncManager = iCloudSyncManager
         }
         // Load all cask releated data
         .task {

--- a/Applite/Views/Content View/ContentView.swift
+++ b/Applite/Views/Content View/ContentView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 import OSLog
-import ButtonKit
 
 struct ContentView: View {
     @EnvironmentObject var caskManager: CaskManager

--- a/Applite/Views/Detail Views/App Migration/AppMigrationView+ExportView.swift
+++ b/Applite/Views/Detail Views/App Migration/AppMigrationView+ExportView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import ButtonKit
 import OSLog
 
 extension AppMigrationView {
@@ -30,10 +29,10 @@ extension AppMigrationView {
                     } label: {
                         Label("Export Apps to File", systemImage: "square.and.arrow.up")
                     }
-                    .controlSize(.large)
                     .onButtonError { error in
                         alert.show(error: error, title: "Failed to export")
                     }
+                    .controlSize(.large)
 
                     if exportSuccessful {
                         Image(systemName: "square.and.arrow.down.badge.checkmark")

--- a/Applite/Views/Detail Views/AppHistoryView.swift
+++ b/Applite/Views/Detail Views/AppHistoryView.swift
@@ -11,6 +11,9 @@ import SwiftUI
 struct AppHistoryView: View {
     @EnvironmentObject var caskManager: CaskManager
     @EnvironmentObject var iCloudSyncManager: ICloudSyncManager
+    @AppStorage(Preferences.iCloudSyncEnabled.rawValue) var iCloudSyncEnabled: Bool = false
+
+    @Environment(\.openURL) var openURL
 
     private var notInstalledCasks: [Cask] {
         iCloudSyncManager.previouslyInstalledCaskIds.compactMap { id in
@@ -22,7 +25,9 @@ struct AppHistoryView: View {
 
     var body: some View {
         VStack {
-            if notInstalledCasks.isEmpty {
+            if !iCloudSyncEnabled {
+                disabledView
+            } else if notInstalledCasks.isEmpty {
                 Text("All previously installed apps are currently installed.")
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -43,5 +48,29 @@ struct AppHistoryView: View {
             }
         }
         .navigationTitle("App History")
+    }
+
+    private var disabledView: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+
+            Text("App History")
+                .font(.title2)
+                .bold()
+
+            Text("Keep track of apps you've installed across all your Macs. Enable iCloud sync in Settings to automatically remember your apps for easy reinstallation.")
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 400)
+
+            Button("Open Settings") {
+                NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+            }
+            .controlSize(.large)
+            .padding(.top, 4)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }

--- a/Applite/Views/Detail Views/AppHistoryView.swift
+++ b/Applite/Views/Detail Views/AppHistoryView.swift
@@ -1,0 +1,47 @@
+//
+//  AppHistoryView.swift
+//  Applite
+//
+//  Created on 2026.02.09.
+//
+
+import SwiftUI
+
+/// Shows previously installed apps that are not currently installed, for easy reinstallation
+struct AppHistoryView: View {
+    @EnvironmentObject var caskManager: CaskManager
+    @EnvironmentObject var iCloudSyncManager: ICloudSyncManager
+
+    private var notInstalledCasks: [Cask] {
+        iCloudSyncManager.previouslyInstalledCaskIds.compactMap { id in
+            guard let cask = caskManager.casks[id], !cask.isInstalled else { return nil }
+            return cask
+        }
+        .sorted()
+    }
+
+    var body: some View {
+        VStack {
+            if notInstalledCasks.isEmpty {
+                Text("All previously installed apps are currently installed.")
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 320))], spacing: 20) {
+                        ForEach(notInstalledCasks) { cask in
+                            AppView(cask: cask, role: .installAndManage)
+                                .contextMenu {
+                                    Button("Remove from History") {
+                                        iCloudSyncManager.removeCask(cask.id)
+                                    }
+                                }
+                        }
+                    }
+                    .padding()
+                }
+            }
+        }
+        .navigationTitle("App History")
+    }
+}

--- a/Applite/Views/Detail Views/Brew Management/BrewManagementView+ActionsView.swift
+++ b/Applite/Views/Detail Views/Brew Management/BrewManagementView+ActionsView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import ButtonKit
 
 extension BrewManagementView {
     struct ActionsView: View {
@@ -128,13 +127,13 @@ extension BrewManagementView {
             } label: {
                 Label("Update Homebrew", systemImage: "arrow.uturn.down.circle")
             }
-            .controlSize(.large)
-            .disabled(modifyingBrew)
-            .padding(.trailing, 3)
             .onButtonError { error in
                 logger.error("Brew update failed. Error: \(error.localizedDescription)")
                 updateFailed = true
             }
+            .controlSize(.large)
+            .disabled(modifyingBrew)
+            .padding(.trailing, 3)
             .alert("Update failed", isPresented: $updateFailed, actions: {})
         }
 

--- a/Applite/Views/Detail Views/Discover/Discover Section/DiscoverSectionView+Placeholder.swift
+++ b/Applite/Views/Detail Views/Discover/Discover Section/DiscoverSectionView+Placeholder.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import Shimmer
 
 extension DiscoverSectionView {
     /// Two placeholder app views on top of each other for the discover app row

--- a/Applite/Views/Detail Views/InstalledView.swift
+++ b/Applite/Views/Detail Views/InstalledView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import DebouncedOnChange
 
 /// Shows installed apps, where the user can open and uninstall them
 struct InstalledView: View {

--- a/Applite/Views/Detail Views/Update/UpdateView+ToolbarItems.swift
+++ b/Applite/Views/Detail Views/Update/UpdateView+ToolbarItems.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import ButtonKit
 
 extension UpdateView {
     struct ToolbarItems: ToolbarContent {

--- a/Applite/Views/Settings/SettingsView+GeneralSettings.swift
+++ b/Applite/Views/Settings/SettingsView+GeneralSettings.swift
@@ -9,13 +9,17 @@ import SwiftUI
 
 extension SettingsView {
     struct GeneralSettingsView: View {
+        @EnvironmentObject var iCloudSyncManager: ICloudSyncManager
+
         @AppStorage(Preferences.colorSchemePreference.rawValue) var colorSchemePreference: ColorSchemePreference = .system
         @AppStorage(Preferences.catalogUpdateFrequency.rawValue) var catalogUpdateFrequency: CatalogUpdateFrequency = .everyAppLaunch
         @AppStorage(Preferences.notificationSuccess.rawValue) var notificationOnSuccess: Bool = false
         @AppStorage(Preferences.notificationFailure.rawValue) var notificationOnFailure: Bool = true
+        @AppStorage(Preferences.iCloudSyncEnabled.rawValue) var iCloudSyncEnabled: Bool = false
 
         /// Needed for a workaround for changing the color scheme
         @State var fixingColor = false
+        @State var showClearConfirmation = false
 
         var body: some View {
             VStack(alignment: .leading) {
@@ -49,6 +53,29 @@ extension SettingsView {
 
                 Toggle("Task completions", isOn: $notificationOnSuccess)
                 Toggle("Task errors", isOn: $notificationOnFailure)
+
+                Divider()
+                    .padding(.vertical)
+
+                Text("iCloud", comment: "iCloud settings title")
+                    .bold()
+
+                Toggle("Sync App History to iCloud", isOn: $iCloudSyncEnabled)
+
+                HStack {
+                    Button("Clear All App History") {
+                        showClearConfirmation = true
+                    }
+                    .disabled(!iCloudSyncEnabled)
+                    .alert("Clear App History", isPresented: $showClearConfirmation) {
+                        Button("Clear", role: .destructive) {
+                            iCloudSyncManager.clearAll()
+                        }
+                        Button("Cancel", role: .cancel) { }
+                    } message: {
+                        Text("This will remove your app history from all devices. Are you sure?")
+                    }
+                }
             }
             .padding()
             .onChange(of: colorSchemePreference) {

--- a/Applite/Views/Setup/SetupView+AppliteBrewInstall.swift
+++ b/Applite/Views/Setup/SetupView+AppliteBrewInstall.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import ButtonKit
 
 extension SetupView {
     /// Brew installation page

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Applite is a macOS GUI application for managing Homebrew Casks, built with Swift 6.0 and SwiftUI. It targets macOS 13+ and aims to be a simple "app store" for third-party apps rather than a full Homebrew wrapper. Bundle ID: `dev.aerolite.Applite`.
+
+## Build & Run
+
+This is an Xcode project (`Applite.xcodeproj`). There is no Makefile or CLI build script.
+
+```bash
+# Build from command line
+xcodebuild -project Applite.xcodeproj -scheme Applite -configuration Debug build
+
+# Build for release
+xcodebuild -project Applite.xcodeproj -scheme Applite -configuration Release build
+```
+
+Open in Xcode for the standard build/run/debug workflow. There are no tests in this project.
+
+## Architecture
+
+### Entry Point & App Lifecycle
+
+`AppliteApp.swift` is the `@main` entry point. It creates a `CaskManager` as `@StateObject` and passes it via `@EnvironmentObject`. On first launch, `SetupView` handles Homebrew detection/installation; thereafter `ContentView` is shown.
+
+### Core Data Flow
+
+**CaskManager** (`Model/Cask Models/Cask Manager/`) is the central state manager:
+- Holds all casks in `[CaskId: Cask]` dictionary
+- Maintains three `SearchableCaskCollection`s: all, installed, outdated
+- Tracks active brew tasks and categories
+- `loadData()` delegates to `CaskDataCoordinator` which fetches from network/cache in parallel
+
+**Cask** (`Model/Cask Models/Cask/`) is the core entity — an `ObservableObject` with `CaskInfo` (static data) and `@Published` state for install status and progress. Protocol conformances are split across extension files (`Cask+Hashable.swift`, `Cask+Searchable.swift`, etc.).
+
+**Data Models** (`Model/Cask Models/Data Models/`): `CaskDTO` for API deserialization, `CaskInfo` for domain model, `BrewAnalytics` for download counts.
+
+### Shell Execution
+
+`Shell` (`Utilities/Shell/Shell.swift`) is the namespace for all shell interactions:
+- `run()` — synchronous execution
+- `runAsync()` — async execution
+- `runBrewCommand()` — brew-specific async execution
+- `stream()` — returns `AsyncThrowingStream<String, Error>` for real-time output
+- Verifies askpass script checksum (MD5) for security before each execution
+- Configures proxy and mirror environment variables automatically
+
+### View Organization
+
+Views are heavily decomposed using Swift extensions:
+- `ContentView` splits into `+SidebarViews`, `+DetailView`, `+LoadCasks`, `+SearchFunctions`
+- `AppView` splits into `+ActionsView`, `+DownloadButton`, `+UpdateButton`, `+UninstallButton`, etc.
+- Major screens: `DiscoverView`, `HomeView`, `InstalledView`, `UpdateView`, `CategoryView`
+- Setup wizard: `SetupView` + multiple extension files for each step
+
+### Key Utilities
+
+- **BrewPaths** (`Utilities/Other/BrewPaths.swift`): Manages multiple brew executable paths (app-specific, Apple Silicon, Intel, custom)
+- **NetworkProxyManager**: System proxy detection (HTTP, HTTPS, SOCKS5)
+- **MirrorEnvironment**: Homebrew mirror configuration for restricted regions
+- **DependencyManager**: Handles Homebrew and Xcode CLT installation
+- **AlertManager**: Centralized alert presentation via view modifier
+
+## Dependencies (Swift Package Manager)
+
+- **Sparkle** — Auto-update framework (appcast.xml at project root)
+- **Kingfisher** — Image downloading/caching (configured with proxy in `AppliteApp.init()`)
+- **Ifrit** (fuse-swift fork) — Fuzzy search for cask names
+- **ButtonKit** — Enhanced async button components
+- **SwiftUI-Shimmer** — Loading placeholder animations
+- **CircularProgressSwiftUI** — Progress indicators
+- **DebouncedOnChange** — Debounced SwiftUI onChange modifier
+
+## Key Patterns
+
+- `@MainActor` on all `ObservableObject` classes (CaskManager, Cask)
+- `async/await` throughout; `AsyncThrowingStream` for streaming brew output
+- `@AppStorage` wrapping `Preferences` enum raw values for UserDefaults
+- `@EnvironmentObject` for injecting `CaskManager` into views
+- Logging via `OSLog` with `Logger` instances per class
+- Localization via `Localizable.xcstrings` (English, French, Hungarian, Japanese, Chinese Simplified)
+
+## Resources
+
+- `Resources/categories.json` — Handpicked app categories for the Discover page
+- `Resources/askpass.js` — JXA script for sudo authentication (checksum-verified)
+- `Resources/brew-tap-cask-info.rb` — Ruby script for fetching tap cask info

--- a/docs/plans/2026-02-09-icloud-app-history-design.md
+++ b/docs/plans/2026-02-09-icloud-app-history-design.md
@@ -1,0 +1,121 @@
+# iCloud App History Sync
+
+## Overview
+
+Add an opt-in iCloud sync feature that tracks every app the user has ever installed via Applite. A new "App History" sidebar section shows previously installed apps that are not currently installed, enabling easy reinstallation on new or wiped machines.
+
+## Approach
+
+Use `NSUbiquitousKeyValueStore` (iCloud Key-Value Store) to sync a `Set<CaskId>` across devices. This is the simplest iCloud mechanism — no CloudKit container or schema needed, just an entitlement. The 1MB limit easily holds thousands of cask ID strings.
+
+## Data Layer
+
+### ICloudSyncManager
+
+New file: `Utilities/ICloudSyncManager.swift`
+
+- `@MainActor final class ICloudSyncManager: ObservableObject`
+- Wraps `NSUbiquitousKeyValueStore.default`
+- Storage key: `"previouslyInstalledCasks"`
+- Serialization: JSON-encoded `[String]` array
+
+**Published state:**
+- `@Published var previouslyInstalledCaskIds: Set<CaskId>`
+
+**Methods:**
+- `addCask(_ id: CaskId)` — insert and write to store (no-op if sync disabled)
+- `addCasks(_ ids: Set<CaskId>)` — bulk insert and write (no-op if sync disabled)
+- `removeCask(_ id: CaskId)` — remove and write to store
+- `clearAll()` — empty the set, write to store, remove from iCloud
+- `sync()` — force read from store
+
+**External change handling:**
+- Subscribe to `NSUbiquitousKeyValueStore.didChangeExternallyNotification` on init
+- On external change: merge remote set with local set (union) to avoid losing installs from concurrent syncs
+- Respects `Preferences.iCloudSyncEnabled` — when off, does not write to the store
+
+## Integration
+
+### Automatic tracking (CaskManager)
+
+1. **On data load** (`CaskManager+LoadData.swift`): After `loadData()` completes, call `iCloudSyncManager.addCasks()` with all currently installed cask IDs.
+
+2. **On install** (`CaskManager+BrewFunctions.swift`): After a successful install action, call `iCloudSyncManager.addCask()` with the newly installed cask ID.
+
+### Environment wiring (AppliteApp.swift)
+
+- Create `ICloudSyncManager` as `@StateObject` in `AppliteApp`
+- Pass as `.environmentObject(iCloudSyncManager)` alongside `caskManager`
+
+## Sidebar
+
+### SidebarItem enum
+
+Add case: `.appHistory`
+
+Place in sidebar between "Active Tasks" and "App Migration".
+
+### Visibility
+
+The "App History" sidebar item is hidden when:
+- iCloud sync is disabled (`Preferences.iCloudSyncEnabled` is false), OR
+- The filtered count is zero (all previously installed apps are currently installed)
+
+Shows a badge with the count of apps available to reinstall.
+
+## Detail View
+
+### AppHistoryView
+
+New file: `Views/Detail Views/AppHistoryView.swift`
+
+- Reuses `AppView` cards (existing component) in a grid layout
+- Filters `iCloudSyncManager.previouslyInstalledCaskIds` against `caskManager.installedCasks` to show only apps not currently installed
+- Each card has a context menu with "Remove from History" calling `iCloudSyncManager.removeCask()`
+- Resolves cask IDs to `Cask` objects via `caskManager.casks` dictionary; silently skips IDs that no longer exist in the catalog
+
+## Settings
+
+### General Settings tab (`SettingsView+GeneralSettings.swift`)
+
+- **Toggle:** "Sync App History to iCloud" — backed by `@AppStorage(Preferences.iCloudSyncEnabled.rawValue)`, defaults to `false`
+- **Clear All button:** Enabled only when toggle is on. Shows confirmation alert: "This will remove your app history from all devices. Are you sure?" On confirm, calls `iCloudSyncManager.clearAll()`
+- When toggled on: immediately syncs currently installed apps to the store
+- When toggled off: stops writing but does not delete existing iCloud data
+
+### Preferences enum
+
+Add case: `iCloudSyncEnabled`
+
+## Entitlements
+
+Add to both `Applite.entitlements` and `AppliteDebug.entitlements`:
+
+```xml
+<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+```
+
+No other iCloud capabilities required.
+
+## Files to create
+
+| File | Description |
+|------|-------------|
+| `Utilities/ICloudSyncManager.swift` | iCloud KVS sync manager |
+| `Views/Detail Views/AppHistoryView.swift` | App History detail view |
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `Model/SidebarItem.swift` | Add `.appHistory` case |
+| `Model/Preferences/Preferences.swift` | Add `iCloudSyncEnabled` case |
+| `AppliteApp.swift` | Create and inject `ICloudSyncManager` |
+| `Views/Content View/ContentView+SidebarViews.swift` | Add App History sidebar item |
+| `Views/Content View/ContentView+DetailView.swift` | Add `.appHistory` detail case |
+| `CaskManager+LoadData.swift` | Sync installed cask IDs after load |
+| `CaskManager+BrewFunctions.swift` | Sync after successful install |
+| `Views/Settings/SettingsView+GeneralSettings.swift` | Add toggle and clear button |
+| `Applite.entitlements` | Add iCloud KVS entitlement |
+| `AppliteDebug.entitlements` | Add iCloud KVS entitlement |


### PR DESCRIPTION
## Summary

- Remove 6 third-party SPM dependencies (Shimmer, DebouncedOnChange, CircularProgressSwiftUI, ButtonKit, Kingfisher, Ifrit) and replace with lightweight native Swift/SwiftUI implementations
- Only Sparkle (auto-update framework) remains as an external dependency
- All replacement code uses modern Swift concurrency and SwiftUI APIs targeting macOS 13+

## New native replacements (7 files)

| Removed Package | Replacement File | Approach |
|---|---|---|
| SwiftUI-Shimmer | `ShimmerModifier.swift` | Animated linear gradient mask |
| DebouncedOnChange | `DebouncedTaskModifier.swift` | SwiftUI `.task(id:)` with `Task.sleep` cancellation |
| CircularProgressSwiftUI | `CircularProgressView.swift` | `Circle().trim()` with percentage text overlay |
| ButtonKit | `AsyncButton.swift` | Custom `AsyncButton` with error handling and style variants |
| Kingfisher | `ImageLoader.swift` + `CachedAsyncImage.swift` | URLSession actor with NSCache/URLCache and proxy support |
| Ifrit (fuse-swift) | `FuzzySearch.swift` | Character-by-character fuzzy matching with weighted scoring |

## Test plan

- [ ] Verify clean build succeeds with `xcodebuild`
- [ ] Launch app and verify app icons load correctly (ImageLoader replacement)
- [ ] Test search functionality works with fuzzy matching (FuzzySearch replacement)
- [ ] Verify shimmer placeholders animate while loading (ShimmerModifier replacement)
- [ ] Test debounced search in Installed/Update/Tap views (DebouncedTaskModifier replacement)
- [ ] Verify download progress circle displays correctly (CircularProgressView replacement)
- [ ] Test all async buttons (install, update, refresh, export, open, get info) work with loading states and error handling (AsyncButton replacement)
- [ ] Verify uninstall self clears image cache properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)