### PR TITLE
open app homepage on command+click

### DIFF
--- a/Applite/Views/App Views/App View/AppView+IconAndDescriptionView.swift
+++ b/Applite/Views/App Views/App View/AppView+IconAndDescriptionView.swift
@@ -11,7 +11,8 @@ extension AppView {
     struct IconAndDescriptionView: View {
         @ObservedObject var cask: Cask
         @AppStorage("showToken") var showToken: Bool = false
-
+        @Environment(\.openURL) private var openURL
+        
         var body: some View {
             HStack {
                 if let iconURL = URL(string: "https://github.com/App-Fair/appcasks/releases/download/cask-\(cask.info.token)/AppIcon.png"),
@@ -41,6 +42,15 @@ extension AppView {
                 Spacer()
             }
             .contentShape(Rectangle())
+            .simultaneousGesture(
+                TapGesture()
+                    .modifiers(.command)
+                    .onEnded {
+                        if let url = cask.info.homepageURL {
+                            openURL(url)
+                        }
+                    }
+            )
         }
     }
 }


### PR DESCRIPTION
introduce a way to open homepage of a particular app using command+click

I found it to be a tedious job, to open a menu each time I wanted to open application homepage, so I added a way to do it faster. Hold command, and click on an app and it will open its homepage. 