### PR TITLE
Redesign settings panes with native grouped Form

### DIFF
--- a/Applite/App/AppDelegate.swift
+++ b/Applite/App/AppDelegate.swift
@@ -8,9 +8,30 @@
 import Foundation
 import AppKit
 
-class ApplicationDelegate: NSObject, NSApplicationDelegate {
+@MainActor
+final class ApplicationDelegate: NSObject, NSApplicationDelegate {
+    /// Set by `AppliteApp` so termination can stop running brew tasks.
+    weak var caskManager: CaskManager?
+
     // Close app after last window closed
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         return true
+    }
+
+    /// Stop any running brew tasks before quitting so no brew/curl processes are
+    /// left running after the app exits.
+    ///
+    /// We deliberately do not show a quit confirmation here: an `NSAlert` is itself
+    /// a window, so when quitting by closing the last window its dismissal re-fires
+    /// termination and the dialog loops. There's no clean way around that today —
+    /// revisit if SwiftUI gains native control over termination.
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        guard let caskManager, !caskManager.activeTasks.isEmpty else { return .terminateNow }
+
+        Task { @MainActor in
+            await caskManager.cancelAllAndWait()
+            NSApp.reply(toApplicationShouldTerminate: true)
+        }
+        return .terminateLater
     }
 }

--- a/Applite/App/AppliteApp.swift
+++ b/Applite/App/AppliteApp.swift
@@ -48,6 +48,10 @@ struct AppliteApp: App {
                     .environment(\.updater, updaterController.updater)
                     .frame(minWidth: 970, minHeight: 520)
                     .preferredColorScheme(selectedColorScheme)
+                    // Give the app delegate the live manager so it can stop running
+                    // tasks on quit. Direct reference — no `NSApp.delegate as?` cast
+                    // or timing fragility.
+                    .onAppear { appDelegate.caskManager = caskManager }
             } else {
                 SetupView()
                     .frame(width: 600, height: 400)

--- a/Applite/AppViews/AppView.swift
+++ b/Applite/AppViews/AppView.swift
@@ -99,8 +99,19 @@ struct AppView: View {
             .scaleEffect(0.8)
 
         case .downloading(let percent):
-            CircularProgressRing(progress: percent)
-                .frame(width: 30, height: 30)
+            Button {
+                caskManager.cancel(cask)
+            } label: {
+                ZStack {
+                    CircularProgressRing(progress: percent)
+                    Image(systemName: "stop.fill")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .buttonStyle(.plain)
+            .frame(width: 30, height: 30)
+            .help("Stop download")
 
         case .success:
             Image(systemName: "checkmark")

--- a/Applite/Components/AppdirSelectorView.swift
+++ b/Applite/Components/AppdirSelectorView.swift
@@ -14,35 +14,37 @@ struct AppdirSelectorView: View {
     @State var choosingAppdir = false
     
     var body: some View {
-        VStack(alignment: .leading) {
-            HStack {
-                Toggle("Use Custom Installation Directory", isOn: $appdirOn)
-
-                InfoPopup(text: "Download apps to a custom directory instead of `/Applications`")
+        Toggle(isOn: $appdirOn) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Use Custom Installation Directory")
+                Text("Install apps to a folder of your choice instead of /Applications. (Homebrew: `--appdir`)", comment: "Appdir setting description")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
-
-            HStack {
-                TextField("Custom Installation Directory", text: $appdirPath, prompt: Text("/path/to/dir"))
-                    .autocorrectionDisabled()
-                    .textFieldStyle(.roundedBorder)
-                
-                Button("Select Folder") {
-                    choosingAppdir = true
-                }
-                .fileImporter(
-                    isPresented: $choosingAppdir,
-                    allowedContentTypes: [.directory]
-                ) { result in
-                    switch result {
-                    case .success(let file):
-                        appdirPath = file.path
-                    case .failure(let error):
-                        print(error.localizedDescription)
-                    }
-                }
-            }
-            .disabled(!appdirOn)
         }
+
+        HStack {
+            TextField("Installation Directory", text: $appdirPath, prompt: Text("/path/to/dir"))
+                .labelsHidden()
+                .autocorrectionDisabled()
+                .textFieldStyle(.roundedBorder)
+
+            Button("Select Folder") {
+                choosingAppdir = true
+            }
+            .fileImporter(
+                isPresented: $choosingAppdir,
+                allowedContentTypes: [.directory]
+            ) { result in
+                switch result {
+                case .success(let file):
+                    appdirPath = file.path
+                case .failure(let error):
+                    print(error.localizedDescription)
+                }
+            }
+        }
+        .disabled(!appdirOn)
     }
 }
 

--- a/Applite/Core/Brew/BrewService.swift
+++ b/Applite/Core/Brew/BrewService.swift
@@ -66,6 +66,12 @@ final class BrewService {
                 busyLabel: String(localized: "Installing", comment: "Install progress text")
             )
 
+            // Stopped by the user — no success/failure surface.
+            if Task.isCancelled {
+                vm.progressState = .idle
+                return
+            }
+
             if case .failure(let error) = result {
                 let completeOutput = error.output
                 var alertMessage = error.underlying.localizedDescription
@@ -157,7 +163,15 @@ final class BrewService {
 
             let command = "\(BrewPaths.currentBrewExecutable.quotedPath()) upgrade --cask \(vm.fullToken)"
 
-            if case .failure(let error) = await self.streamBrewCommand(command, vm: vm, busyLabel: updateLabel) {
+            let result = await self.streamBrewCommand(command, vm: vm, busyLabel: updateLabel)
+
+            // Stopped by the user — no success/failure surface.
+            if Task.isCancelled {
+                vm.progressState = .idle
+                return
+            }
+
+            if case .failure(let error) = result {
                 await self.showFailure(
                     for: vm,
                     error: error.underlying,
@@ -187,7 +201,15 @@ final class BrewService {
 
             let command = "\(BrewPaths.currentBrewExecutable.quotedPath()) reinstall --cask \(vm.fullToken)"
 
-            if case .failure(let error) = await self.streamBrewCommand(command, vm: vm, busyLabel: reinstallLabel) {
+            let result = await self.streamBrewCommand(command, vm: vm, busyLabel: reinstallLabel)
+
+            // Stopped by the user — no success/failure surface.
+            if Task.isCancelled {
+                vm.progressState = .idle
+                return
+            }
+
+            if case .failure(let error) = result {
                 await self.showFailure(
                     for: vm,
                     error: error.underlying,
@@ -218,6 +240,15 @@ final class BrewService {
         for vm in vms {
             self.update(vm)
         }
+    }
+
+    /// Stops the cask's in-progress streaming operation (install, update, reinstall).
+    ///
+    /// Cancelling the task finishes the output stream, which terminates the
+    /// underlying brew process (see `Shell.stream`). The operation then sees
+    /// `Task.isCancelled` and resets the cask back to idle.
+    func cancel(_ vm: CaskViewModel) {
+        activeTasks.first { $0.viewModel == vm }?.task.cancel()
     }
 
     /// Gets additional info for a cask from brew CLI

--- a/Applite/Core/Brew/BrewService.swift
+++ b/Applite/Core/Brew/BrewService.swift
@@ -251,6 +251,26 @@ final class BrewService {
         activeTasks.first { $0.viewModel == vm }?.task.cancel()
     }
 
+    /// Cancels every active task and waits for them to unwind (terminating their
+    /// brew processes via `Shell.stream`'s onTermination), bounded by a timeout so
+    /// quitting can never block indefinitely. Used by the quit-confirmation flow.
+    func cancelAllAndWait() async {
+        let tasks = activeTasks.map(\.task)
+        for task in tasks { task.cancel() }
+
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask {
+                for task in tasks { await task.value }
+            }
+            group.addTask {
+                try? await Task.sleep(for: .seconds(2))
+            }
+            // Return as soon as either all tasks finished unwinding or the timeout fired.
+            await group.next()
+            group.cancelAll()
+        }
+    }
+
     /// Gets additional info for a cask from brew CLI
     func getAdditionalInfoForCask(_ vm: CaskViewModel) async throws -> CaskAdditionalInfo {
         let json = try await Shell.runBrewCommand(["info", "--json=v2", "--cask", vm.fullToken])

--- a/Applite/Core/Brew/Shell.swift
+++ b/Applite/Core/Brew/Shell.swift
@@ -92,9 +92,32 @@ enum Shell {
     /// Using the `pty` option can leave unwanted characters in the output, use only when necessary
     static func stream(_ command: String, pty: Bool = false) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { continuation in
+            let task: Process
+            let pipe: Pipe
+
+            do {
+                (task, pipe) = try createProcess(command: command, pty: pty)
+            } catch {
+                continuation.finish(throwing: error)
+                return
+            }
+
+            // Terminate the process if the consumer cancels (or otherwise stops iterating).
+            //
+            // This is a hard kill, not a graceful cancellation: `terminate()` sends SIGTERM
+            // to the `script` wrapper, which closes the pty and SIGHUPs the foreground
+            // process group (brew + curl). brew does NOT run its cooperative SIGINT-cancel
+            // path here — SIGINT can't be used because `script` ignores it (so a real Ctrl-C
+            // passes through to the child instead of killing the wrapper). The hard kill is
+            // safe for the download phase: brew downloads to `*.incomplete` temp files and
+            // only renames them on success, and its cache locks are OS `flock`s that the
+            // kernel releases on process death. Worst case is a resumable leftover temp file.
+            continuation.onTermination = { _ in
+                if task.isRunning { task.terminate() }
+            }
+
             Task {
                 do {
-                    let (task, pipe) = try createProcess(command: command, pty: pty)
                     let fileHandle = pipe.fileHandleForReading
 
                     try task.run()

--- a/Applite/Core/CaskCore/CaskManager.swift
+++ b/Applite/Core/CaskCore/CaskManager.swift
@@ -110,6 +110,10 @@ final class CaskManager {
         brewService.reinstall(cask)
     }
 
+    func cancel(_ cask: CaskViewModel) {
+        brewService.cancel(cask)
+    }
+
     func installAll(_ casks: [CaskViewModel]) {
         brewService.installAll(casks)
     }

--- a/Applite/Core/CaskCore/CaskManager.swift
+++ b/Applite/Core/CaskCore/CaskManager.swift
@@ -114,6 +114,10 @@ final class CaskManager {
         brewService.cancel(cask)
     }
 
+    func cancelAllAndWait() async {
+        await brewService.cancelAllAndWait()
+    }
+
     func installAll(_ casks: [CaskViewModel]) {
         brewService.installAll(casks)
     }

--- a/Applite/Features/Settings/BrewSettingsView.swift
+++ b/Applite/Features/Settings/BrewSettingsView.swift
@@ -29,103 +29,102 @@ struct BrewSettingsView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading) {
+        Form {
             pathSettings
-            divider
-
             tapSettings
-            divider
-
             appdirSettings
-            divider
-
             otherFlags
-
-            refreshCatalogPrompt
-                .padding(.top)
         }
+        .formStyle(.grouped)
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            refreshCatalogBanner
+        }
+        .animation(.default, value: needsRefresh)
+        .animation(.default, value: isSelectedBrewPathValid)
         .onAppear {
             previousBrewOption = BrewPaths.selectedBrewOption.rawValue
             previousIncludeCasksFromTaps = includeCasksFromTaps
         }
-        .padding()
-    }
-
-    var divider: some View {
-        Divider()
-            .padding(.vertical, 8)
     }
 
     var pathSettings: some View {
-        VStack(alignment: .leading) {
-            Text("Brew Executable Path", comment: "Settings brew path selector")
-                .bold()
-
+        Section("Brew Executable Path") {
             BrewPathSelectorView(isSelectedPathValid: $isSelectedBrewPathValid)
 
-            Text("Currently selected brew path is invalid", comment: "Settings invalid brew path message")
-                .foregroundStyle(.red)
-                .opacity(isSelectedBrewPathValid ? 0 : 1)
+            if !isSelectedBrewPathValid {
+                Text("Currently selected brew path is invalid", comment: "Settings invalid brew path message")
+                    .foregroundStyle(.red)
+                    .transition(.opacity)
+            }
         }
     }
 
-    /// Prompt asking the user to refresh the catalog after a setting that
-    /// affects the catalog (brew path or tap inclusion) has changed. Reserves
-    /// a fixed height so the form doesn't jump when it appears.
-    var refreshCatalogPrompt: some View {
-        HStack {
-            Image(systemName: "exclamationmark.arrow.circlepath")
-                .imageScale(.large)
-                .foregroundStyle(.yellow)
+    /// Banner asking the user to refresh the catalog after a setting that
+    /// affects the catalog (brew path or tap inclusion) has changed. Pinned to
+    /// the bottom of the pane via `safeAreaInset` so it stays visible even when
+    /// the form is scrolled.
+    @ViewBuilder
+    var refreshCatalogBanner: some View {
+        if needsRefresh {
+            VStack(spacing: 0) {
+                Divider()
 
-            Text("Refresh the app catalog to apply your changes")
+                HStack {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .imageScale(.large)
+                        .foregroundStyle(.yellow)
 
-            Spacer()
+                    Text("Refresh the app catalog to apply your changes")
 
-            AsyncButton {
-                await caskManager.loadData(forceSync: true)
-                previousBrewOption = brewPathOption
-                previousIncludeCasksFromTaps = includeCasksFromTaps
-            } label: {
-                Label("Refresh Catalog", systemImage: "arrow.clockwise")
+                    Spacer()
+
+                    AsyncButton {
+                        await caskManager.loadData(forceSync: true)
+                        previousBrewOption = brewPathOption
+                        previousIncludeCasksFromTaps = includeCasksFromTaps
+                    } label: {
+                        Label("Refresh Catalog", systemImage: "arrow.clockwise")
+                    }
+                    .disabled(caskManager.isRefreshingCatalog || !isSelectedBrewPathValid)
+                }
+                .padding(.horizontal)
+                .padding(.vertical, 10)
+                .background(.bar)
             }
-            .disabled(caskManager.isRefreshingCatalog || !isSelectedBrewPathValid)
+            .transition(.move(edge: .bottom).combined(with: .opacity))
         }
-        .frame(height: 32)
-        .opacity(needsRefresh ? 1 : 0)
     }
 
     var tapSettings: some View {
-        VStack(alignment: .leading) {
-            Text("Taps", comment: "Brew settings tap section title")
-                .bold()
-
-            Toggle("Include Casks from Taps", isOn: $includeCasksFromTaps)
+        Section("App Sources") {
+            Toggle(isOn: $includeCasksFromTaps) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Include Third-Party Taps", comment: "Brew settings tap toggle title")
+                    Text("Also show apps from Homebrew taps (third-party repositories) you've added manually. (Homebrew: `tap`)", comment: "Brew settings tap toggle description")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
         }
     }
 
     var appdirSettings: some View {
-        VStack(alignment: .leading) {
-            Text("Appdir", comment: "Brew settings appdir section title")
-                .bold()
-
+        Section("Installation Location") {
             AppdirSelectorView()
         }
     }
 
     var otherFlags: some View {
-        VStack(alignment: .leading) {
-            Text("Other Flags", comment: "Brew settings command line flags section title")
-                .bold()
-
+        Section("Advanced") {
             GreedyUpgradeToggle()
 
-            HStack {
-                Toggle(isOn: $noQuarantine) {
-                    Text("No Quarantine", comment: "Brew no quarantine flag toggle title")
+            Toggle(isOn: $noQuarantine) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Trust Unregistered Developers", comment: "Brew no quarantine flag toggle title")
+                    Text("Lets apps from developers Apple hasn't verified open without Gatekeeper warnings. Only enable if you trust the source. **Use at your own risk!** (Homebrew: `--no-quarantine`)", comment: "Brew no quarantine flag toggle description")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
-
-                InfoPopup(text: "Bypasses the Apple Gatekeeper check, which can be useful if the app is from an unregistered developer. **Use it at your own risk!**")
             }
         }
     }

--- a/Applite/Features/Settings/GeneralSettingsView.swift
+++ b/Applite/Features/Settings/GeneralSettingsView.swift
@@ -17,39 +17,30 @@ struct GeneralSettingsView: View {
     @State var fixingColor = false
 
     var body: some View {
-        VStack(alignment: .leading) {
-            Text("Appearance", comment: "Appearnace settings title")
-                .bold()
-
-            Picker("Color Scheme:", selection: $colorSchemePreference) {
-                ForEach(ColorSchemePreference.allCases) { color in
-                    Text(color.description)
+        Form {
+            Section("Appearance") {
+                Picker("Color Scheme:", selection: $colorSchemePreference) {
+                    ForEach(ColorSchemePreference.allCases) { color in
+                        Text(color.description)
+                    }
                 }
+                .pickerStyle(.segmented)
             }
-            .pickerStyle(.segmented)
 
-            Divider()
-                .padding(.vertical)
-
-            Text("App Catalog", comment: "Catalog settings title")
-                .bold()
-
-            Picker("Fetch app catalog every:", selection: $catalogUpdateFrequency) {
-                ForEach(CatalogUpdateFrequency.allCases) { freq in
-                    Text(freq.description)
+            Section("App Catalog") {
+                Picker("Fetch app catalog every:", selection: $catalogUpdateFrequency) {
+                    ForEach(CatalogUpdateFrequency.allCases) { freq in
+                        Text(freq.description)
+                    }
                 }
             }
 
-            Divider()
-                .padding(.vertical)
-
-            Text("Notifications", comment: "Notification settings title")
-                .bold()
-
-            Toggle("Task completions", isOn: $notificationOnSuccess)
-            Toggle("Task errors", isOn: $notificationOnFailure)
+            Section("Notifications") {
+                Toggle("Successful installs & updates", isOn: $notificationOnSuccess)
+                Toggle("Failed installs & updates", isOn: $notificationOnFailure)
+            }
         }
-        .padding()
+        .formStyle(.grouped)
         .onChange(of: colorSchemePreference) { _, colorScheme in
             // Don't remove this!
             // This is here because changing the .preferredColorScheme view modifier is bugged

--- a/Applite/Features/Settings/GreedyUpgradeToggle.swift
+++ b/Applite/Features/Settings/GreedyUpgradeToggle.swift
@@ -8,18 +8,38 @@
 import SwiftUI
 
 struct GreedyUpgradeToggle: View {
+    /// How the explanation is presented alongside the toggle.
+    enum DescriptionPlacement {
+        /// Caption beneath the title — fits a grouped `Form` (Settings).
+        case inline
+        /// Info popover beside the title — fits compact contexts (toolbar).
+        case popover
+    }
+
+    var descriptionPlacement: DescriptionPlacement = .inline
+
     @AppStorage(Preferences.greedyUpgrade) var greedyUpgrade
-    
+
     var body: some View {
-        HStack {
-            Toggle(isOn: $greedyUpgrade) {
-                Text("Greedy Upgrade", comment: "Brew greedy flag toggle title")
+        Toggle(isOn: $greedyUpgrade) {
+            switch descriptionPlacement {
+            case .inline:
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Include Self-Updating Apps", comment: "Brew greedy flag toggle title")
+                    Text("Show updates for apps that normally update themselves, which are hidden by default. (Homebrew: `--greedy`)", comment: "Brew greedy flag toggle description")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            case .popover:
+                HStack {
+                    Text("Include Self-Updating Apps", comment: "Brew greedy flag toggle title")
+
+                    InfoPopup(
+                        text: "Show updates for apps that normally update themselves, which are hidden by default. (Homebrew: `--greedy`)",
+                        extraPaddingForLines: 3
+                    )
+                }
             }
-            
-            InfoPopup(
-                text: "Enabling greedy upgrade will list all outdated apps, even those that have built-in update mechanisms and handle their own updates.",
-                extraPaddingForLines: 3
-            )
         }
     }
 }

--- a/Applite/Features/Settings/MirrorsView.swift
+++ b/Applite/Features/Settings/MirrorsView.swift
@@ -15,35 +15,34 @@ struct MirrorsView: View {
     @AppStorage(Preferences.mirrorBottleDomain) var bottleDomain
 
     var body: some View {
-        VStack(alignment: .leading) {
-            Text("Mirror")
-                .bold()
+        Form {
+            Section("Mirror") {
+                Toggle("Enabled", isOn: $mirrorEnabled)
 
-            Toggle("Enabled", isOn: $mirrorEnabled)
-
-            Menu("Presets") {
-                ForEach(mirrorPresets) { preset in
-                    Button(preset.name) {
-                        apiDomain = preset.apiDomain
-                        brewGitRemote = preset.brewGitRemote
-                        coreGitRemote = preset.coreGitRemote
-                        bottleDomain = preset.bottleDomain
+                LabeledContent("Presets") {
+                    Menu("Presets") {
+                        ForEach(mirrorPresets) { preset in
+                            Button(preset.name) {
+                                apiDomain = preset.apiDomain
+                                brewGitRemote = preset.brewGitRemote
+                                coreGitRemote = preset.coreGitRemote
+                                bottleDomain = preset.bottleDomain
+                            }
+                        }
                     }
+                    .menuStyle(.borderedButton)
+                    .fixedSize()
                 }
             }
-            .menuStyle(.borderedButton)
 
-            Divider()
-                .padding(.vertical)
-
-            VStack(alignment: .leading, spacing: 12) {
+            Section("Environment Variables") {
                 EnvironmentInput(title: "HOMEBREW_API_DOMAIN", text: $apiDomain)
                 EnvironmentInput(title: "HOMEBREW_BREW_GIT_REMOTE", text: $brewGitRemote)
                 EnvironmentInput(title: "HOMEBREW_CORE_GIT_REMOTE", text: $coreGitRemote)
                 EnvironmentInput(title: "HOMEBREW_BOTTLE_DOMAIN", text: $bottleDomain)
             }
         }
-        .padding()
+        .formStyle(.grouped)
     }
 
     struct EnvironmentInput: View {
@@ -51,10 +50,12 @@ struct MirrorsView: View {
         @Binding var text: String
 
         var body: some View {
-            VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 2) {
                 Text(title)
-                    .fontWeight(.light)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
                 TextField(title, text: $text)
+                    .labelsHidden()
                     .textFieldStyle(.roundedBorder)
             }
         }

--- a/Applite/Features/Settings/ProxySettingsView.swift
+++ b/Applite/Features/Settings/ProxySettingsView.swift
@@ -12,25 +12,23 @@ struct ProxySettingsView: View {
     @AppStorage(Preferences.preferredProxyType) var preferredProxyType
 
     var body: some View {
-        VStack(alignment: .leading) {
-            Toggle("Use system proxy", isOn: $proxyEnabled)
+        Form {
+            Section {
+                Toggle("Use system proxy", isOn: $proxyEnabled)
 
-            Picker("Preferred proxy protocol", selection: $preferredProxyType) {
-                ForEach(NetworkProxyType.allCases, id: \.self) { proxyType in
-                    Text(proxyType.displayName)
-                        .tag(proxyType.rawValue)
+                Picker("Preferred proxy protocol", selection: $preferredProxyType) {
+                    ForEach(NetworkProxyType.allCases, id: \.self) { proxyType in
+                        Text(proxyType.displayName)
+                            .tag(proxyType.rawValue)
+                    }
                 }
+            } footer: {
+                Text(
+                    "Applite can use the system network proxy, but only one protocol (HTTP, HTTPS, or SOCKS5). Select your preferred method.",
+                    comment: "Proxy settings description"
+                )
             }
-            .padding(.bottom)
-
-            Text(
-                "Applite uses the system network proxy, but it can only use one protocol (HTTP, HTTPS, or SOCKS5). Select your preferred method.",
-                comment: "Proxy settings description"
-            )
-            .font(.system(.body, weight: .light))
-            .frame(minHeight: 60)
         }
-        .frame(maxWidth: 350)
-        .padding()
+        .formStyle(.grouped)
     }
 }

--- a/Applite/Features/Settings/SettingsView.swift
+++ b/Applite/Features/Settings/SettingsView.swift
@@ -73,7 +73,7 @@ struct SettingsView: View {
                 NSApp.keyWindow?.makeFirstResponder(nil)
             }
         }
-        .frame(width: 440)
+        .frame(width: 500, height: 460)
     }
 }
 

--- a/Applite/Features/Settings/UninstallView.swift
+++ b/Applite/Features/Settings/UninstallView.swift
@@ -11,18 +11,18 @@ struct UninstallView: View {
     @Environment(\.openWindow) var openWindow
 
     var body: some View {
-        VStack(alignment: .center) {
-            Button(role: .destructive) {
-                openWindow(id: "uninstall-self")
-            } label: {
-                Label("Uninstall", systemImage: "trash.fill")
+        Form {
+            Section {
+                Button(role: .destructive) {
+                    openWindow(id: "uninstall-self")
+                } label: {
+                    Label("Uninstall Applite", systemImage: "trash")
+                        .foregroundStyle(.red)
+                }
+            } footer: {
+                Text("Uninstall Applite, related files and cache.", comment: "Settings Uninstall Applite view description")
             }
-            .buttonStyle(.borderedProminent)
-            .tint(.red)
-            .controlSize(.large)
-
-            Text("Uninstall Applite, related files and cache.", comment: "Settings Uninstall Applite view description")
         }
-        .padding()
+        .formStyle(.grouped)
     }
 }

--- a/Applite/Features/Settings/UpdateSettingsView.swift
+++ b/Applite/Features/Settings/UpdateSettingsView.swift
@@ -21,29 +21,30 @@ struct UpdateSettingsView: View {
     }
 
     var body: some View {
-        VStack {
-            Button(action: updater.checkForUpdates) {
-                Label("Check for Updates...", systemImage: "arrow.triangle.2.circlepath")
+        Form {
+            Section {
+                Button(action: updater.checkForUpdates) {
+                    Label("Check for Updates...", systemImage: "arrow.triangle.2.circlepath")
+                }
+
+                LabeledContent("Current app version") {
+                    Text("\(Bundle.main.version) (\(Bundle.main.buildNumber))", comment: "Update settings current app version text (version, build number)")
+                }
             }
 
-            Text("Current app version: \(Bundle.main.version) (\(Bundle.main.buildNumber))", comment: "Update settings current app version text (version, build number)")
-                .font(.system(.body, weight: .light))
-                .foregroundStyle(.secondary)
+            Section {
+                Toggle("Automatically check for updates", isOn: $automaticallyChecksForUpdates)
+                    .onChange(of: automaticallyChecksForUpdates) { _, newValue in
+                        updater.automaticallyChecksForUpdates = newValue
+                    }
 
-            Spacer()
-                .frame(height: 20)
-
-            Toggle("Automatically check for updates", isOn: $automaticallyChecksForUpdates)
-                .onChange(of: automaticallyChecksForUpdates) { _, newValue in
-                    updater.automaticallyChecksForUpdates = newValue
-                }
-
-            Toggle("Automatically download updates", isOn: $automaticallyDownloadsUpdates)
-                .disabled(!automaticallyChecksForUpdates)
-                .onChange(of: automaticallyDownloadsUpdates) { _, newValue in
-                    updater.automaticallyDownloadsUpdates = newValue
-                }
+                Toggle("Automatically download updates", isOn: $automaticallyDownloadsUpdates)
+                    .disabled(!automaticallyChecksForUpdates)
+                    .onChange(of: automaticallyDownloadsUpdates) { _, newValue in
+                        updater.automaticallyDownloadsUpdates = newValue
+                    }
+            }
         }
-        .padding()
+        .formStyle(.grouped)
     }
 }

--- a/Applite/Features/Updates/UpdateToolbar.swift
+++ b/Applite/Features/Updates/UpdateToolbar.swift
@@ -15,7 +15,7 @@ struct UpdateToolbar: ToolbarContent {
     var body: some ToolbarContent {
         if #available(macOS 26.0, *) {
             ToolbarItem {
-                GreedyUpgradeToggle()
+                GreedyUpgradeToggle(descriptionPlacement: .popover)
                     .padding(.horizontal)
                     .toggleStyle(.checkbox)
             }
@@ -28,7 +28,7 @@ struct UpdateToolbar: ToolbarContent {
         } else {
             ToolbarItemGroup {
                 HStack {
-                    GreedyUpgradeToggle()
+                    GreedyUpgradeToggle(descriptionPlacement: .popover)
                         .toggleStyle(.checkbox)
 
                     Spacer()

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -452,6 +452,17 @@
         }
       }
     },
+    "%@ (%@)" : {
+      "comment" : "Update settings current app version text (version, build number)",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ (%2$@)"
+          }
+        }
+      }
+    },
     "%@ is already installed. If you want to add it to Applite click more options (chevron icon) and press Force Install." : {
       "comment" : "App already installed alert message (parameter: app name)",
       "localizations" : {
@@ -903,6 +914,9 @@
         }
       }
     },
+    "Advanced" : {
+
+    },
     "After reinstalling, all currently installed apps will be unlinked from Applite. They won't be deleted, but you won't be able to update or uninstall them via Applite." : {
       "comment" : "Brew reinstall warning",
       "localizations" : {
@@ -1069,6 +1083,9 @@
     },
     "All your apps are up to date." : {
       "comment" : "Update view no updates available description"
+    },
+    "Also show apps from Homebrew taps (third-party repositories) you've added manually. (Homebrew: `tap`)" : {
+      "comment" : "Brew settings tap toggle description"
     },
     "App Catalog" : {
       "comment" : "Catalog settings title",
@@ -1316,8 +1333,12 @@
         }
       }
     },
+    "App Sources" : {
+
+    },
     "Appdir" : {
       "comment" : "Brew settings appdir section title",
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -1480,6 +1501,9 @@
         }
       }
     },
+    "Applite can use the system network proxy, but only one protocol (HTTP, HTTPS, or SOCKS5). Select your preferred method." : {
+      "comment" : "Proxy settings description"
+    },
     "Applite couldn't open %@" : {
       "comment" : "App couldn't be opened alert",
       "localizations" : {
@@ -1523,6 +1547,7 @@
     },
     "Applite uses the system network proxy, but it can only use one protocol (HTTP, HTTPS, or SOCKS5). Select your preferred method." : {
       "comment" : "Proxy settings description",
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -2257,7 +2282,8 @@
       }
     },
     "Bypasses the Apple Gatekeeper check, which can be useful if the app is from an unregistered developer. **Use it at your own risk!**" : {
-      "comment" : "No quarantine toggle info popup",
+      "comment" : "Brew no quarantine flag toggle description",
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -2798,8 +2824,12 @@
         }
       }
     },
+    "Current app version" : {
+
+    },
     "Current app version: %@ (%@)" : {
       "comment" : "Update settings current app version text (version, build number)",
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2970,6 +3000,7 @@
     },
     "Custom Installation Directory" : {
       "comment" : "Appdir textfield",
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -3254,6 +3285,7 @@
     },
     "Download apps to a custom directory instead of `/Applications`" : {
       "comment" : "Appdir toggle info popup ",
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -3419,6 +3451,7 @@
     },
     "Enabling greedy upgrade will list all outdated apps, even those that have built-in update mechanisms and handle their own updates." : {
       "comment" : "Greedy update info popup",
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -3457,6 +3490,9 @@
           }
         }
       }
+    },
+    "Environment Variables" : {
+
     },
     "Error" : {
       "comment" : "Cask action failed (e.g. installation failed)",
@@ -3662,6 +3698,9 @@
           }
         }
       }
+    },
+    "Failed installs & updates" : {
+
     },
     "Failed to export" : {
       "comment" : "Alert message",
@@ -4233,6 +4272,7 @@
     },
     "Greedy Upgrade" : {
       "comment" : "Brew greedy flag toggle title",
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -4767,6 +4807,7 @@
     },
     "Include Casks from Taps" : {
       "comment" : "Third-party taps settings toggle",
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -4805,6 +4846,12 @@
           }
         }
       }
+    },
+    "Include Self-Updating Apps" : {
+      "comment" : "Brew greedy flag toggle title"
+    },
+    "Include Third-Party Taps" : {
+      "comment" : "Brew settings tap toggle title"
     },
     "Info" : {
       "comment" : "Brew Management view info section title",
@@ -4846,6 +4893,9 @@
           }
         }
       }
+    },
+    "Install apps to a folder of your choice instead of /Applications. (Homebrew: `--appdir`)" : {
+      "comment" : "Appdir setting description"
     },
     "Install Separate Brew" : {
       "comment" : "Brew Management button",
@@ -4929,6 +4979,9 @@
         }
       }
     },
+    "Installation Directory" : {
+
+    },
     "Installation failed" : {
       "comment" : "App install alert",
       "localizations" : {
@@ -4969,6 +5022,9 @@
           }
         }
       }
+    },
+    "Installation Location" : {
+
     },
     "Installed" : {
       "comment" : "Brew dependency installed badge text",
@@ -5133,6 +5189,9 @@
           }
         }
       }
+    },
+    "Lets apps from developers Apple hasn't verified open without Gatekeeper warnings. Only enable if you trust the source. **Use at your own risk!** (Homebrew: `--no-quarantine`)" : {
+      "comment" : "Brew no quarantine flag toggle description"
     },
     "Light" : {
       "comment" : "Color mode",
@@ -5634,6 +5693,7 @@
     },
     "No Quarantine" : {
       "comment" : "Brew no quarantine flag toggle title",
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -5923,6 +5983,7 @@
     },
     "Other Flags" : {
       "comment" : "Brew settings command line flags section title",
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -6918,6 +6979,9 @@
         }
       }
     },
+    "Show updates for apps that normally update themselves, which are hidden by default. (Homebrew: `--greedy`)" : {
+      "comment" : "Brew greedy flag toggle description"
+    },
     "Sort By" : {
       "comment" : "Sorting option picker",
       "localizations" : {
@@ -7043,6 +7107,9 @@
     "Stop download" : {
 
     },
+    "Successful installs & updates" : {
+
+    },
     "System" : {
       "comment" : "Color mode",
       "extractionState" : "manual",
@@ -7128,6 +7195,7 @@
     },
     "Task completions" : {
       "comment" : "Notification settings toggle",
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -7169,6 +7237,7 @@
     },
     "Task errors" : {
       "comment" : "Notification settings toggle",
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -7536,6 +7605,9 @@
           }
         }
       }
+    },
+    "Trust Unregistered Developers" : {
+      "comment" : "Brew no quarantine flag toggle title"
     },
     "Turn off few downloads filter" : {
       "comment" : "Filter disable button",

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -7040,6 +7040,9 @@
         }
       }
     },
+    "Stop download" : {
+
+    },
     "System" : {
       "comment" : "Color mode",
       "extractionState" : "manual",


### PR DESCRIPTION
## Summary

Reworks the Settings window to use SwiftUI's native `Form` with `.formStyle(.grouped)` — the same grouped "card" style as macOS System Settings — and clarifies Homebrew jargon for non-technical users.

Previously all six panes were hand-rolled `VStack`s, which had drifted apart: inconsistent root alignment, ad-hoc `Text(...).bold()` section headers (or none), two different font-weight APIs, and one-off `.frame`/`.padding` constraints. Converting every pane to `Form { Section … }` removes all of that and stops future drift. The top tab-bar shell is kept (a sidebar/list style is only warranted with many panes).

## Changes

**Native grouped `Form`**
- All 6 panes converted to `Form` + `.formStyle(.grouped)` with `Section` headers and footers
- Descriptive copy moved into section footers (Proxy, Uninstall), which render in the native secondary style
- Settings window widened slightly with a fixed frame so it doesn't jump between tabs

**Clearer labels (Homebrew jargon → plain language)**
- *No Quarantine* → **Trust Unregistered Developers**
- *Greedy Upgrade* → **Include Self-Updating Apps**
- *Include Casks from Taps* → **Include Third-Party Taps**
- Section titles: *Appdir* → **Installation Location**, *Taps* → **App Sources**, *Other Flags* → **Advanced**
- Notification toggles: *Task completions* / *Task errors* → **Successful installs & updates** / **Failed installs & updates**
- Info popovers replaced with inline caption descriptions that note the underlying Homebrew flag (e.g. `--greedy`)

**Brew pane refinements**
- Catalog-refresh prompt pinned to a bottom safe-area banner so it stays visible when scrolled
- Invalid-path message and refresh banner animate via `.animation(_:value:)`
- Fixed the Appdir field cramping and the duplicated Mirrors field labels

**Shared component**
- `GreedyUpgradeToggle` gains a `descriptionPlacement` parameter: `.inline` caption in Settings, `.popover` in the Updates toolbar (compact, as before) — one component, two presentations

## Test plan
- `xcodebuild` succeeds
- Open Settings (⌘,) and verify all 6 tabs render grouped cards with consistent typography and no per-tab size jump
- Brew: changing brew path / taps shows the pinned refresh banner; invalid path message animates in/out
- Updates toolbar: greedy toggle shows the info popover, not the inline caption

🤖 Generated with [Claude Code](https://claude.com/claude-code)