### PR TITLE
Fix incorrect fallback letters for missing cask icons

### DIFF
--- a/Applite/AppViews/AppIconView.swift
+++ b/Applite/AppViews/AppIconView.swift
@@ -11,7 +11,6 @@ import Shimmer
 
 enum AppIconState {
     case showingAppIcon
-    case showingFavicon
     case failed
 }
 
@@ -19,12 +18,12 @@ struct AppIconView: View {
     @State private var state: AppIconState = .showingAppIcon
 
     let iconURL: URL
-    let faviconURL: URL
     let cacheKey: String
+    let fallbackInitial: String
 
     var body: some View {
-        if state != .failed {
-            KFImage.url(state == .showingAppIcon ? iconURL : faviconURL, cacheKey: cacheKey)
+        if state == .showingAppIcon {
+            KFImage.url(iconURL, cacheKey: cacheKey)
                 .resizable()
                 .placeholder {
                     RoundedRectangle(cornerRadius: 12, style: .continuous)
@@ -32,30 +31,22 @@ struct AppIconView: View {
                         .shimmering()
                 }
                 .fade(duration: 0.25)
-                .onFailure { error in
-                    // Change state
-                    switch state {
-                    case .showingAppIcon:
-                        state = .showingFavicon
-                    case .showingFavicon:
-                        state = .failed
-                    default:
-                        state = .failed
-                    }
+                .onFailure { _ in
+                    state = .failed
                 }
                 .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
                 .frame(width: 54, height: 54)
         } else {
-            // App icon missing
+            // A homepage favicon can describe the host rather than the cask.
             ZStack {
                 RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .stroke(.gray, lineWidth: 3)
+                    .fill(.gray)
 
-                Text("?")
-                    .font(.system(size: 24, weight: .light))
+                Text(fallbackInitial)
+                    .font(.system(size: 24, weight: .medium))
             }
-            .foregroundStyle(.gray)
-            .frame(width: 40, height: 40)
+            .foregroundStyle(.white)
+            .frame(width: 54, height: 54)
         }
     }
 }

--- a/Applite/AppViews/IconAndDescriptionView.swift
+++ b/Applite/AppViews/IconAndDescriptionView.swift
@@ -14,12 +14,11 @@ struct IconAndDescriptionView: View {
     
     var body: some View {
         HStack {
-            if let iconURL = URL(string: "https://github.com/App-Fair/appcasks/releases/download/cask-\(cask.token)/AppIcon.png"),
-               let faviconURL = URL(string: "https://icon.horse/icon/\(cask.homepage?.host ?? "")") {
+            if let iconURL = URL(string: "https://github.com/App-Fair/appcasks/releases/download/cask-\(cask.token)/AppIcon.png") {
                 AppIconView(
                     iconURL: iconURL,
-                    faviconURL: faviconURL,
-                    cacheKey: cask.token
+                    cacheKey: cask.token,
+                    fallbackInitial: cask.name.first.map { String($0).uppercased() } ?? "?"
                 )
                 .padding(.leading, 5)
             }


### PR DESCRIPTION
## Summary

When an App-Fair cask icon is unavailable, Applite currently falls back to the
homepage favicon. Those favicons describe the website rather than the cask,
producing incorrect letter tiles such as `I` for Pearcleaner and Viz.

Use the uppercase first character of the cask name as a deterministic local
fallback instead.

Fixes #132.

## Validation

- reviewed all five screenshots attached to #132
- `git diff --check`
- `xcodebuild -project Applite.xcodeproj -scheme Applite -configuration Debug CODE_SIGNING_ALLOWED=NO build`

## AI assistance

AI assistance was used for investigation and drafting. I reviewed the issue screenshots, endpoint behavior, and complete diff, then independently completed an unsigned local build.
