### PR TITLE
App Migration v2: selectable Brewfile export/import

### DIFF
--- a/Applite/AppViews/AppIconView.swift
+++ b/Applite/AppViews/AppIconView.swift
@@ -21,6 +21,7 @@ struct AppIconView: View {
     let iconURL: URL
     let faviconURL: URL
     let cacheKey: String
+    var size: CGFloat = 54
 
     var body: some View {
         if state != .failed {
@@ -44,7 +45,7 @@ struct AppIconView: View {
                     }
                 }
                 .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-                .frame(width: 54, height: 54)
+                .frame(width: size, height: size)
         } else {
             // App icon missing
             ZStack {
@@ -52,10 +53,10 @@ struct AppIconView: View {
                     .stroke(.gray, lineWidth: 3)
 
                 Text("?")
-                    .font(.system(size: 24, weight: .light))
+                    .font(.system(size: size * 0.44, weight: .light))
             }
             .foregroundStyle(.gray)
-            .frame(width: 40, height: 40)
+            .frame(width: size * 0.74, height: size * 0.74)
         }
     }
 }

--- a/Applite/AppViews/IconAndDescriptionView.swift
+++ b/Applite/AppViews/IconAndDescriptionView.swift
@@ -14,12 +14,11 @@ struct IconAndDescriptionView: View {
     
     var body: some View {
         HStack {
-            if let iconURL = URL(string: "https://github.com/App-Fair/appcasks/releases/download/cask-\(cask.token)/AppIcon.png"),
-               let faviconURL = URL(string: "https://icon.horse/icon/\(cask.homepage?.host ?? "")") {
+            if let iconURL = cask.iconURL, let faviconURL = cask.faviconURL {
                 AppIconView(
                     iconURL: iconURL,
                     faviconURL: faviconURL,
-                    cacheKey: cask.token
+                    cacheKey: cask.iconCacheKey
                 )
                 .padding(.leading, 5)
             }

--- a/Applite/Core/CaskCore/CaskViewModel.swift
+++ b/Applite/Core/CaskCore/CaskViewModel.swift
@@ -107,6 +107,26 @@ final class CaskViewModel {
     )
 }
 
+// MARK: - Icon URLs
+
+extension CaskViewModel {
+    /// Primary app-icon URL (App-Fair appcasks release asset).
+    ///
+    /// Centralized here so every icon call site (app cards, the migration selection sheet) shares
+    /// one source — the single edit point when the icon source is swapped.
+    var iconURL: URL? {
+        URL(string: "https://github.com/App-Fair/appcasks/releases/download/cask-\(token)/AppIcon.png")
+    }
+
+    /// Fallback favicon URL derived from the homepage host.
+    var faviconURL: URL? {
+        URL(string: "https://icon.horse/icon/\(homepage?.host ?? "")")
+    }
+
+    /// Stable Kingfisher cache key for the icon.
+    var iconCacheKey: String { token }
+}
+
 // MARK: -  Protocol conformances
 
 // MARK: - Identifiable

--- a/Applite/Features/AppMigration/AppMigration.swift
+++ b/Applite/Features/AppMigration/AppMigration.swift
@@ -13,36 +13,47 @@ enum CaskImportError: Error {
 }
 
 enum AppMigration {
-    static func export() async throws -> ExportFile {
-        let output = try await Shell.runBrewCommand(["list", "--cask", "--full-name"])
+    /// Builds Brewfile-syntax text from the selected view models: a `tap "user/repo"` line for each
+    /// distinct non-default tap present, then a `cask "<fullToken>"` line per app. Output is sorted
+    /// so exports are deterministic. Uses `fullToken` so cross-tap setups re-import cleanly.
+    ///
+    /// `@MainActor` because `CaskViewModel`'s `tap`/`fullToken` are main-actor isolated.
+    @MainActor
+    static func makeBrewfile(from casks: [CaskViewModel]) -> String {
+        let taps = Set(casks.map(\.tap))
+            .subtracting(["homebrew/cask"])
+            .sorted()
 
-        let exportedCasks = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        let tapLines = taps.map { "tap \"\($0)\"" }
+        let caskLines = casks
+            .map(\.fullToken)
+            .sorted()
+            .map { "cask \"\($0)\"" }
 
-        return ExportFile(initialText: exportedCasks)
+        return (tapLines + caskLines).joined(separator: "\n") + "\n"
     }
 
     static func readCaskFile(url: URL) throws -> Set<CaskId> {
         let content = try String(contentsOf: url)
         var casks: Set<CaskId> = []
-        let brewfileRegex = /cask "([\w-]+)"/
+        // `[\w/-]+` (not `[\w-]+`) so tap-qualified tokens like `user/repo/token` also match.
+        // Extended delimiters `#/.../#` let the `/` appear unescaped without ending the literal.
+        let brewfileRegex = #/cask "([\w/-]+)"/#
 
         // Check if the file being imported is a Brewfile
         // Brewfiles store casks as cask "caskName"
         if content.contains("cask \"") {
-            // Brewfile
+            // Brewfile — `tap "..."` lines are intentionally ignored (brew auto-taps on install of
+            // a full-token cask).
             let matches = content.matches(of: brewfileRegex)
             casks.formUnion(
                 matches.map({ String($0.1) })
             )
         } else {
-            // Try to load casks as an Applite txt file export
+            // Legacy Applite txt export: one token per line, trimmed.
             casks.formUnion(
                 content.components(separatedBy: .newlines)
-            )
-            
-            // Trim whitespace
-            casks.formUnion(
-                casks.map({ $0.trimmingCharacters(in: .whitespaces) })
+                    .map({ $0.trimmingCharacters(in: .whitespaces) })
             )
         }
 

--- a/Applite/Features/AppMigration/AppMigrationView.swift
+++ b/Applite/Features/AppMigration/AppMigrationView.swift
@@ -8,48 +8,50 @@
 import SwiftUI
 
 struct AppMigrationView: View {
-    let width: CGFloat = 620
-    let cardPadding: CGFloat = 24
+    private let width: CGFloat = 620
+    private let cardPadding: CGFloat = 24
+    private let cardHeight: CGFloat = 320
 
     var body: some View {
-        ScrollView {
-            VStack {
-                titleAndDescription
-                    .padding(.vertical, 40)
-                
-                HStack(spacing: 40) {
-                    Card(padding: cardPadding) {
-                        ExportAppsView()
-                    }
-                    
-                    Card(padding: cardPadding) {
-                        ImportAppsView()
-                    }
+        VStack(spacing: 0) {
+            titleAndDescription
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Spacer(minLength: 24)
+
+            HStack(spacing: 32) {
+                Card(padding: cardPadding) {
+                    ExportAppsView()
                 }
-                
-                Spacer()
+
+                Card(padding: cardPadding) {
+                    ImportAppsView()
+                }
             }
-            .navigationTitle("App Migration")
-            .frame(maxWidth: width)
-            .padding()
+            .frame(maxHeight: cardHeight)
+
+            Spacer(minLength: 24)
         }
+        .frame(maxWidth: width, maxHeight: .infinity)   // fill height, cap width
+        .frame(maxWidth: .infinity)                     // center the column in the pane
+        .padding(40)
+        .navigationTitle("App Migration")
     }
 
-    var titleAndDescription: some View {
-        VStack(alignment: .leading) {
+    private var titleAndDescription: some View {
+        VStack(alignment: .leading, spacing: 4) {
             Text("App Migration", comment: "App Migration view title")
                 .font(.appliteMediumTitle)
-                .padding(.bottom, 2)
 
             Text(
-                "Export all of your currently installed apps to a file. Import the file to another device to install them all. Useful when setting up a new Mac.",
+                "Export your installed apps to a file, then import it on another Mac to reinstall them all — the easy way to set up a new machine.",
                 comment: "App migration view description"
             )
+            .foregroundStyle(.secondary)
         }
     }
 }
 
 #Preview {
     AppMigrationView()
-        .padding()
 }

--- a/Applite/Features/AppMigration/CaskSelectionSheet.swift
+++ b/Applite/Features/AppMigration/CaskSelectionSheet.swift
@@ -1,0 +1,165 @@
+//
+//  CaskSelectionSheet.swift
+//  Applite
+//
+//  Created by Milán Várady on 2026.08.02.
+//
+
+import SwiftUI
+
+/// A reusable checklist sheet for picking which casks to export or import.
+///
+/// The caller owns the data and presents it via `.sheet`; the sheet seeds every row as selected,
+/// offers a Select-All/Deselect-All toggle and a live count, and returns the chosen view models
+/// through `onConfirm` before dismissing itself.
+struct CaskSelectionSheet: View {
+    let title: LocalizedStringKey
+    let confirmLabel: LocalizedStringKey
+    /// Optional caption shown above the list (e.g. "N apps could not be found" on import).
+    let note: LocalizedStringKey?
+    /// Caller passes these pre-sorted.
+    let casks: [CaskViewModel]
+    let onConfirm: ([CaskViewModel]) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    /// Keyed by `cask.id` (== `fullToken`), seeded with all ids so every row starts checked.
+    @State private var selectedTokens: Set<String>
+
+    init(
+        title: LocalizedStringKey,
+        confirmLabel: LocalizedStringKey,
+        note: LocalizedStringKey? = nil,
+        casks: [CaskViewModel],
+        onConfirm: @escaping ([CaskViewModel]) -> Void
+    ) {
+        self.title = title
+        self.confirmLabel = confirmLabel
+        self.note = note
+        self.casks = casks
+        self.onConfirm = onConfirm
+        _selectedTokens = State(initialValue: Set(casks.map(\.id)))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            Divider()
+
+            List(casks) { cask in
+                row(for: cask)
+            }
+            .listStyle(.inset)
+
+            Divider()
+
+            footer
+        }
+        .frame(width: 460, height: 520)
+    }
+
+    // MARK: - Private views (coupled to @State → kept in-file per project convention)
+
+    private var allSelected: Bool {
+        !casks.isEmpty && selectedTokens.count == casks.count
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(title)
+                    .font(.headline)
+
+                Spacer()
+
+                Text("\(selectedTokens.count) selected", comment: "Cask selection sheet count")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+
+            Toggle(isOn: selectAllBinding) {
+                Text(allSelected ? "Deselect All" : "Select All", comment: "Cask selection sheet select-all toggle")
+            }
+            .toggleStyle(.checkbox)
+
+            if let note {
+                Text(note)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding()
+    }
+
+    private func row(for cask: CaskViewModel) -> some View {
+        Toggle(isOn: binding(for: cask)) {
+            HStack(spacing: 8) {
+                if let iconURL = cask.iconURL, let faviconURL = cask.faviconURL {
+                    AppIconView(
+                        iconURL: iconURL,
+                        faviconURL: faviconURL,
+                        cacheKey: cask.iconCacheKey,
+                        size: 24
+                    )
+                }
+
+                Text(cask.name)
+            }
+        }
+        .toggleStyle(.checkbox)
+    }
+
+    private var footer: some View {
+        HStack {
+            Button("Cancel", role: .cancel) {
+                dismiss()
+            }
+            .keyboardShortcut(.cancelAction)
+
+            Spacer()
+
+            Button {
+                onConfirm(casks.filter { selectedTokens.contains($0.id) })
+                dismiss()
+            } label: {
+                Text(confirmLabel)
+            }
+            .keyboardShortcut(.defaultAction)
+            .disabled(selectedTokens.isEmpty)
+        }
+        .padding()
+    }
+
+    // MARK: - Bindings
+
+    private var selectAllBinding: Binding<Bool> {
+        Binding(
+            get: { allSelected },
+            set: { selectAll in
+                selectedTokens = selectAll ? Set(casks.map(\.id)) : []
+            }
+        )
+    }
+
+    private func binding(for cask: CaskViewModel) -> Binding<Bool> {
+        Binding(
+            get: { selectedTokens.contains(cask.id) },
+            set: { isOn in
+                if isOn {
+                    selectedTokens.insert(cask.id)
+                } else {
+                    selectedTokens.remove(cask.id)
+                }
+            }
+        )
+    }
+}
+
+#Preview {
+    CaskSelectionSheet(
+        title: "Select Apps to Export",
+        confirmLabel: "Export",
+        casks: [.dummy]
+    ) { _ in }
+}

--- a/Applite/Features/AppMigration/ExportAppsView.swift
+++ b/Applite/Features/AppMigration/ExportAppsView.swift
@@ -6,58 +6,81 @@
 //
 
 import SwiftUI
-import ButtonKit
 import OSLog
 
 struct ExportAppsView: View {
-    @State var showFileExporter = false
-    @State var exportFile: ExportFile = .init()
-    @State var exportSuccessful = false
-    @State var alert = AlertManager()
+    @Environment(CaskManager.self) private var caskManager
+
+    @State private var showSelectionSheet = false
+    @State private var showFileExporter = false
+    @State private var exportFile = ExportFile()
+    /// Set when the selection sheet is confirmed; the file exporter is opened from `onDismiss` so it
+    /// never races the selection sheet's own dismissal.
+    @State private var hasPendingExport = false
+    @State private var exportSuccessful = false
+    @State private var alert = AlertManager()
 
     private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "AppMigration.ExportAppsView")
 
+    /// Bare stem (no extension) — `.plainText` appends `.txt`, so adding it here would double it.
+    private static var defaultFilename: String {
+        "Applite-export-\(Date.now.formatted(.iso8601.year().month().day().dateSeparator(.dash)))"
+    }
+
+    /// Installed apps to offer for export, excluding Applite itself: an import only ever runs from
+    /// inside a running Applite, so it is always already installed — listing it is redundant.
+    /// (Mirrors `AppGridView`, which hides the self-cask.)
+    private var exportableCasks: [CaskViewModel] {
+        caskManager.installedViewModels.filter { $0.token != "applite" }
+    }
+
     var body: some View {
         VStack(spacing: 12) {
+            Spacer(minLength: 0)
+
             Image(systemName: "tray.and.arrow.up.fill")
-                .font(.system(size: 40))
+                .font(.system(size: 44))
                 .foregroundStyle(.tint)
 
             Text("Export", comment: "App migration export card title")
                 .font(.appliteSmallTitle)
 
-            Text("Export all apps currently installed by Applite to a file.", comment: "App Migration export card description")
+            Text("Save your selected apps to a file you can import on another Mac.",
+                 comment: "App Migration export card description")
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
 
-            Spacer()
+            Spacer(minLength: 12)
 
-            HStack {
-                AsyncButton {
-                    // Handle the failure inside the action rather than via `.onButtonStateError`,
-                    // which re-fires on every re-render while the button stays in its sticky error
-                    // state — so dismissing the alert would immediately re-present it in a loop.
-                    do {
-                        exportFile = try await AppMigration.export()
-                        showFileExporter = true
-                    } catch {
-                        alert.show(error: error, title: "Failed to export")
-                    }
-                } label: {
-                    Label("Export Apps to File", systemImage: "square.and.arrow.up")
-                }
-                .controlSize(.large)
-
-                if exportSuccessful {
-                    Image(systemName: "square.and.arrow.down.badge.checkmark")
-                        .foregroundStyle(.green)
-                        .imageScale(.large)
-                }
+            Button {
+                showSelectionSheet = true
+            } label: {
+                Text("Export Apps…", comment: "App Migration export button")
             }
+            .cardActionPill()
+            .disabled(exportableCasks.isEmpty)
+
+            statusLine
         }
         .frame(maxWidth: .infinity)
         .alertManager(alert)
-        .fileExporter(isPresented: $showFileExporter, document: exportFile,  contentType: .plainText, defaultFilename: "applite_export") { result in
+        .sheet(isPresented: $showSelectionSheet, onDismiss: {
+            if hasPendingExport {
+                hasPendingExport = false
+                showFileExporter = true
+            }
+        }) {
+            CaskSelectionSheet(
+                title: "Select Apps to Export",
+                confirmLabel: "Export",
+                casks: exportableCasks
+            ) { selected in
+                exportFile = ExportFile(initialText: AppMigration.makeBrewfile(from: selected))
+                hasPendingExport = true
+            }
+        }
+        .fileExporter(isPresented: $showFileExporter, document: exportFile, contentType: .plainText, defaultFilename: Self.defaultFilename) { result in
             switch result {
             case .success(let url):
                 logger.notice("Successful cask export: \(url.path(percentEncoded: false))")
@@ -67,5 +90,22 @@ struct ExportAppsView: View {
                 alert.show(error: error, title: "Failed to export")
             }
         }
+    }
+
+    /// Confirmation / waiting caption under the button. Shown in a fixed-height slot so the card
+    /// layout doesn't shift when it appears.
+    @ViewBuilder
+    private var statusLine: some View {
+        Group {
+            if exportSuccessful {
+                Label("Saved to file", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+            } else if exportableCasks.isEmpty && caskManager.isResolvingInstalledState {
+                Text("Waiting for installed apps to load…", comment: "App Migration export waiting caption")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .font(.callout)
+        .frame(height: 20)
     }
 }

--- a/Applite/Features/AppMigration/ImportAppsView.swift
+++ b/Applite/Features/AppMigration/ImportAppsView.swift
@@ -11,60 +11,84 @@ import OSLog
 struct ImportAppsView: View {
     @Environment(CaskManager.self) var caskManager
 
-    @State var showFileImporter = false
-    @State var importSuccessful = false
-    @State var importedCount = 0
-    @State var alert = AlertManager()
+    @State private var showFileImporter = false
+    /// Drives the selection sheet. Using `.sheet(item:)` (not a separate bool + array) makes the
+    /// sheet's content a pure function of the resolved casks, so it can never present with a stale
+    /// empty list — the race that showed "0 casks" on the first import attempt.
+    @State private var importSelection: ImportSelection?
+    @State private var importSuccessful = false
+    @State private var importedCount = 0
+    @State private var alert = AlertManager()
 
     private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "AppMigration.ImportAppsView")
 
     var body: some View {
         VStack(spacing: 12) {
+            Spacer(minLength: 0)
+
             Image(systemName: "tray.and.arrow.down.fill")
-                .font(.system(size: 40))
+                .font(.system(size: 44))
                 .foregroundStyle(.tint)
 
             Text("Import", comment: "App Migration import card title")
                 .font(.appliteSmallTitle)
 
-            Text(
-                "**Tip:** You can also import apps from a Brewfile. However, only casks will be installed, other items like formulae and taps will be skipped.",
-                comment: "App Migration import card tip"
-            )
-            .multilineTextAlignment(.center)
-            .foregroundStyle(.secondary)
+            Text("Install apps from a file exported by Applite — or any Brewfile.",
+                 comment: "App Migration import card description")
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
 
-            Spacer()
+            Spacer(minLength: 12)
 
             Button {
                 showFileImporter = true
             } label: {
-                Label("Import Apps", systemImage: "square.and.arrow.down")
+                Text("Import Apps…", comment: "App Migration import button")
             }
-            .controlSize(.large)
+            .cardActionPill()
 
-            if importSuccessful {
-                Label("Installing \(importedCount) apps…", systemImage: "checkmark.circle")
-                    .foregroundStyle(.green)
-                    .font(.callout)
+            Group {
+                if importSuccessful {
+                    Label("Installing \(importedCount) apps…", systemImage: "checkmark.circle")
+                        .foregroundStyle(.green)
+                }
             }
+            .font(.callout)
+            .frame(height: 20)
         }
         .frame(maxWidth: .infinity)
         .alertManager(alert)
-        .fileImporter(isPresented: $showFileImporter, allowedContentTypes: [.plainText, .data]) { result in
+        // `.item` allows any file so extensionless Brewfiles are selectable, not greyed out.
+        .fileImporter(isPresented: $showFileImporter, allowedContentTypes: [.item]) { result in
             switch result {
             case .success(let url):
-                installCasks(from: url)
+                gatherCasks(from: url)
             case .failure(let error):
                 alert.show(error: error, title: "Failed to import")
             }
         }
+        .sheet(item: $importSelection) { selection in
+            CaskSelectionSheet(
+                title: "Select Apps to Import",
+                confirmLabel: "Install",
+                note: selection.notFoundCount > 0 ? "\(selection.notFoundCount) apps could not be found" : nil,
+                casks: selection.casks
+            ) { selected in
+                caskManager.installAll(selected)
+                withAnimation {
+                    importedCount = selected.count
+                    importSuccessful = true
+                }
+            }
+        }
     }
 
-    private func installCasks(from url: URL) {
-        let caskIds: Set<CaskId>
+    /// Parses the file, resolves its tokens against the DB, then shows the selection sheet.
+    private func gatherCasks(from url: URL) {
+        let tokens: Set<CaskId>
         do {
-            caskIds = try AppMigration.readCaskFile(url: url)
+            tokens = try AppMigration.readCaskFile(url: url)
         } catch {
             logger.error("Failed to import file: \(url.path(percentEncoded: false))")
             alert.show(title: "Imported file contains no valid apps", message: "Check if file contains valid cask tokens")
@@ -73,20 +97,31 @@ struct ImportAppsView: View {
 
         Task {
             // Resolve against the DB so casks the user has never opened still install.
-            let casksToInstall = (try? await caskManager.resolveViewModels(forTokens: caskIds)) ?? []
+            let resolvedAll = (try? await caskManager.resolveViewModels(forTokens: tokens)) ?? []
 
-            guard !casksToInstall.isEmpty else {
+            // Count not-found from the full resolved set so an Applite entry isn't mislabeled as
+            // missing — it resolved, we just don't offer it (the import runs from a live Applite,
+            // so it's always already installed).
+            let matched = Set(resolvedAll.flatMap { [$0.token, $0.fullToken] })
+            let resolved = resolvedAll.filter { $0.token != "applite" }.sorted()
+
+            guard !resolved.isEmpty else {
                 logger.notice("Imported file contains no valid apps: \(url.path(percentEncoded: false))")
                 alert.show(title: "Imported file contains no valid apps", message: "Check if file contains valid cask tokens")
                 return
             }
 
-            caskManager.installAll(casksToInstall)
-
-            withAnimation {
-                importedCount = casksToInstall.count
-                importSuccessful = true
-            }
+            importSelection = ImportSelection(
+                casks: resolved,
+                notFoundCount: tokens.subtracting(matched).count
+            )
         }
     }
+}
+
+/// Identifiable payload for the import selection sheet.
+private struct ImportSelection: Identifiable {
+    let id = UUID()
+    let casks: [CaskViewModel]
+    let notFoundCount: Int
 }

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -280,6 +280,7 @@
     },
     "**Tip:** You can also import apps from a Brewfile. However, only casks will be installed, other items like formulae and taps will be skipped." : {
       "comment" : "App Migration import card tip",
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -675,6 +676,9 @@
         }
       }
     },
+    "%lld apps could not be found" : {
+
+    },
     "%lld apps installed" : {
       "comment" : "Bulk install success notification"
     },
@@ -702,6 +706,9 @@
           }
         }
       }
+    },
+    "%lld selected" : {
+      "comment" : "Cask selection sheet count"
     },
     "3 days" : {
       "comment" : "App catalog frequency option",
@@ -2188,6 +2195,7 @@
     },
     "Broken Brew Path" : {
       "comment" : "Broken brew path alert title",
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -3216,6 +3224,9 @@
     "Deprecated" : {
 
     },
+    "Deselect All" : {
+
+    },
     "Developer Tools" : {
       "comment" : "App category",
       "extractionState" : "manual",
@@ -3340,6 +3351,9 @@
     },
     "Dismiss" : {
 
+    },
+    "Done" : {
+      "comment" : "Accessibility label for the success checkmark"
     },
     "Download Anyway" : {
       "comment" : "App download confirmation button",
@@ -3681,6 +3695,7 @@
     },
     "Export all apps currently installed by Applite to a file." : {
       "comment" : "App Migration export card description",
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -3722,6 +3737,7 @@
     },
     "Export all of your currently installed apps to a file. Import the file to another device to install them all. Useful when setting up a new Mac." : {
       "comment" : "App migration view description",
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -3763,6 +3779,7 @@
     },
     "Export Apps to File" : {
       "comment" : "App export button",
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -3801,6 +3818,12 @@
           }
         }
       }
+    },
+    "Export Apps…" : {
+      "comment" : "App Migration export button"
+    },
+    "Export your installed apps to a file, then import it on another Mac to reinstall them all — the easy way to set up a new machine." : {
+      "comment" : "App migration view description"
     },
     "Failed installs & updates" : {
 
@@ -4805,6 +4828,7 @@
     },
     "Import Apps" : {
       "comment" : "Import apps button",
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
@@ -4843,6 +4867,9 @@
           }
         }
       }
+    },
+    "Import Apps…" : {
+      "comment" : "App Migration import button"
     },
     "Imported file contains no valid apps" : {
       "comment" : "Alert message",
@@ -5018,6 +5045,9 @@
     },
     "Install" : {
 
+    },
+    "Install apps from a file exported by Applite — or any Brewfile." : {
+      "comment" : "App Migration import card description"
     },
     "Install apps to a folder of your choice instead of /Applications. (Homebrew: `--appdir`)" : {
       "comment" : "Appdir setting description"
@@ -6963,6 +6993,12 @@
         }
       }
     },
+    "Save your selected apps to a file you can import on another Mac." : {
+      "comment" : "App Migration export card description"
+    },
+    "Saved to file" : {
+
+    },
     "Search Sorting Options" : {
       "localizations" : {
         "fr" : {
@@ -7046,6 +7082,15 @@
           }
         }
       }
+    },
+    "Select All" : {
+
+    },
+    "Select Apps to Export" : {
+
+    },
+    "Select Apps to Import" : {
+
     },
     "Select Folder" : {
       "comment" : "Appdir folder selector",
@@ -8703,6 +8748,9 @@
           }
         }
       }
+    },
+    "Waiting for installed apps to load…" : {
+      "comment" : "App Migration export waiting caption"
     },
     "Waiting…" : {
       "comment" : "Queued brew operation label"

--- a/Testing/applite_test.py
+++ b/Testing/applite_test.py
@@ -1104,21 +1104,47 @@ def phase_a13(_state) -> None:
 
 
 def phase_a14(_state) -> None:
-    step("11", "export + BULK install (one batch process)")
-    # Import runs installAll → a single `brew install --cask <all>` process. This is the
-    # original dropped-casks repro (importing 2 casks once needed 3 tries) plus the batch UI.
-    export_path = Path.home() / "Desktop/applite_export.txt"
-    do_in_app(f"App Migration → Export apps to {export_path}")
-    check("export file exists and is non-empty",
-          lambda: export_path.exists() and export_path.stat().st_size > 0)
+    step("11", "export (selectable Brewfile) + BULK install (one batch process)")
+    # Migration v2: Export and Import each open a CHECKLIST SHEET first (pick which apps).
+    # Export then writes a Brewfile (`cask "<token>"` lines, plus `tap "…"` for non-default taps)
+    # via the save panel, default name Applite-export-<date>.txt. Import resolves tokens against
+    # the DB (installs casks never browsed) and force-installs, so an already-present cask
+    # reinstalls instead of failing the batch. Import runs installAll → a single
+    # `brew install --cask <all>` process (the original dropped-casks repro plus the batch UI).
+    desktop = Path.home() / "Desktop"
+    # Clear stale exports so the glob below matches only this run's file.
+    for old in glob.glob(str(desktop / "Applite-export-*.txt")):
+        try:
+            os.remove(old)
+        except OSError:
+            pass
 
-    # Import the whole set. Import resolves tokens against the DB (installs casks never browsed)
-    # and force-installs, so an already-present cask reinstalls instead of failing the batch.
-    import_path = Path.home() / "Desktop/applite_import.txt"
+    do_in_app("App Migration → Export Apps to File (a selection sheet should open)")
+    confirm("Did a selection sheet list your installed apps, each PRE-CHECKED and showing an "
+            "icon, with Applite itself NOT in the list (excluded — you're already running it)?")
+    confirm("Do 'Select All' / 'Deselect All' flip every checkbox and the \"N selected\" count "
+            "update live?")
+    do_in_app("Make sure all are checked, press Export, and SAVE to the Desktop "
+              "(accept the default name Applite-export-<date>.txt)")
+
+    exports = sorted(glob.glob(str(desktop / "Applite-export-*.txt")))
+    check("a dated export appeared on the Desktop (Applite-export-*.txt)",
+          lambda: bool(exports))
+    if exports:
+        text = Path(exports[-1]).read_text()
+        check("export is Brewfile syntax (has cask \"…\" lines)",
+              lambda t=text: 'cask "' in t)
+
+    # Import a controlled set. A plain-text token list also exercises the legacy-format import
+    # path (readCaskFile falls back to newline-separated tokens when there's no `cask "` line).
+    import_path = desktop / "applite_import.txt"
     import_path.write_text("\n".join(BULK_INSTALL_CASKS) + "\n")
     info(f"import file: {', '.join(BULK_INSTALL_CASKS)}")
 
-    do_in_app(f"App Migration → Import {import_path}; let the batch run to completion")
+    do_in_app(f"App Migration → Import → pick {import_path}")
+    confirm(f"Did the import selection sheet show ALL {len(BULK_INSTALL_CASKS)} apps on the "
+            "FIRST attempt? (regression: it used to list 0 the first time.)")
+    do_in_app("Leave every app checked, press Install, and let the batch run to completion")
     confirm(f"Did each of the {len(BULK_INSTALL_CASKS)} cards show its OWN download ring "
             "(not just a spinner) during the download phase?")
     confirm("Did the Active Tasks header count up (\"Installing X of N…\")?")
@@ -1132,7 +1158,8 @@ def phase_bulk_update(state) -> None:
     # Reuse the fonts installed by the bulk-install phase; fake them outdated, then Update All.
     targets = [t for t in BULK_UPDATE_CASKS if cask_installed(t)]
     if len(targets) < 2:
-        do_in_app(f"Install {BULK_UPDATE_CASKS} first if missing (App Migration import)")
+        do_in_app(f"Install {BULK_UPDATE_CASKS} first if missing (App Migration → Import → "
+                  "select all → Install)")
         targets = [t for t in BULK_UPDATE_CASKS if cask_installed(t)]
     if len(targets) < 2:
         RESULTS.skip("bulk update (need ≥2 installed update targets)")
@@ -1172,7 +1199,8 @@ def phase_batch_stop(state) -> None:
                   "(they must re-download for this test)")
     stop_path = Path.home() / "Desktop/applite_bulkstop.txt"
     stop_path.write_text("\n".join(BULK_STOP_CASKS) + "\n")
-    do_in_app(f"Import {stop_path} ({', '.join(BULK_STOP_CASKS)}) — big downloads, keep it running")
+    do_in_app(f"App Migration → Import → pick {stop_path} ({', '.join(BULK_STOP_CASKS)}); in the "
+              "selection sheet leave both checked and press Install — big downloads, keep it running")
 
     do_in_app("While it downloads, click the STOP button on ONE app card")
     confirm("Did an alert appear (\"…is part of a bulk operation\") with a 'See Active Tasks' "


### PR DESCRIPTION
## Summary

Reworks App Migration from an all-or-nothing flow into a **selectable checklist** with a proper **Brewfile** format, and redesigns the detail view. This strengthens Applite's core differentiator — being the *first app you install on a new Mac* — by making "export my apps → restore them on another machine" a curated, one-click experience.

## What changed

**Selectable export/import**
- New `CaskSelectionSheet`: reusable native checklist (checkbox + icon + name), with Select-All/Deselect-All, a live "N selected" count, all rows pre-checked.
- **Export** opens the sheet, then writes a Brewfile (`tap "…"` lines for non-default taps + sorted `cask "…"` lines) via the save panel. Default filename `Applite-export-<date>.txt` (renamable).
- **Import** allows any file type (so extensionless `Brewfile`s are selectable), resolves tokens against the DB, then shows the sheet before installing.

**Fixes**
- Import uses `.sheet(item:)` instead of `.sheet(isPresented:)` — the old approach raced the just-dismissed file importer and could present an empty list on the first attempt.
- Widened the import regex to match tap-qualified tokens (`user/repo/token`).
- Applite itself is excluded from both lists — an import always runs from a live Applite, so it's already installed.

**Groundwork + polish**
- Centralized icon URLs on `CaskViewModel` (`iconURL`/`faviconURL`/`iconCacheKey`) and added an optional `size` to `AppIconView` — this also makes a future icon-source swap a one-file change.
- Redesigned `AppMigrationView`: hero header + vertically centered cards that fill the pane, `cardActionPill()` buttons, and an accurate import description (the old Brewfile "tip" was stale).
- Updated the `Testing/applite_test.py` harness for the new selection sheets and Brewfile export (including a regression check for the first-attempt empty-list bug).

## Testing
- `xcodebuild … BUILD SUCCEEDED` (0 errors).
- Brewfile regex + dated-filename logic verified with a standalone Swift check.
- Interactive export/import flow verified in-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)