### PR TITLE
Modernize app icons: CaskFlow source + monogram fallback

### DIFF
--- a/Applite/AppViews/AppIconView.swift
+++ b/Applite/AppViews/AppIconView.swift
@@ -9,54 +9,76 @@ import SwiftUI
 import Kingfisher
 import Shimmer
 
-enum AppIconState {
-    case showingAppIcon
-    case showingFavicon
-    case failed
-}
-
 struct AppIconView: View {
-    @State private var state: AppIconState = .showingAppIcon
+    @State private var iconFailed = false
 
     let iconURL: URL
-    let faviconURL: URL
+    /// App display name — its first letter is shown in the monogram fallback.
+    let name: String
     let cacheKey: String
     var size: CGFloat = 54
 
-    var body: some View {
-        if state != .failed {
-            KFImage.url(state == .showingAppIcon ? iconURL : faviconURL, cacheKey: cacheKey)
-                .resizable()
-                .placeholder {
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .fill(.gray)
-                        .shimmering()
-                }
-                .fade(duration: 0.25)
-                .onFailure { error in
-                    // Change state
-                    switch state {
-                    case .showingAppIcon:
-                        state = .showingFavicon
-                    case .showingFavicon:
-                        state = .failed
-                    default:
-                        state = .failed
-                    }
-                }
-                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-                .frame(width: size, height: size)
-        } else {
-            // App icon missing
-            ZStack {
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .stroke(.gray, lineWidth: 3)
+    private var cornerRadius: CGFloat { size * 0.2 }
 
-                Text("?")
-                    .font(.system(size: size * 0.44, weight: .light))
+    var body: some View {
+        Group {
+            if iconFailed {
+                monogram
+            } else {
+                KFImage.url(iconURL, cacheKey: cacheKey)
+                    .resizable()
+                    .placeholder {
+                        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                            .fill(.gray)
+                            .shimmering()
+                    }
+                    .fade(duration: 0.25)
+                    .onFailure { _ in iconFailed = true }
+                    .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
             }
-            .foregroundStyle(.gray)
-            .frame(width: size * 0.74, height: size * 0.74)
         }
+        .frame(width: size, height: size)
     }
+
+    /// Deterministic letter-on-color tile shown when the remote icon can't be loaded. Replaces the
+    /// old third-party favicon fallback: no network round-trip, no privacy leak, works offline, and
+    /// reads as intentional rather than a broken image.
+    private var monogram: some View {
+        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            .fill(monogramColor)
+            .overlay {
+                Text(monogramLetter)
+                    .font(.system(size: size * 0.5, weight: .medium))
+                    .foregroundStyle(.white)
+            }
+    }
+
+    private var monogramLetter: String {
+        name.first.map { String($0).uppercased() } ?? "?"
+    }
+
+    /// Stable, pleasant color seeded from the cache key so a given app always gets the same tile.
+    private var monogramColor: Color {
+        let hash = cacheKey.unicodeScalars.reduce(UInt64(5381)) { ($0 &* 31) &+ UInt64($1.value) }
+        let hue = Double(hash % 360) / 360
+        return Color(hue: hue, saturation: 0.55, brightness: 0.6)
+    }
+}
+
+#Preview {
+    HStack(spacing: 16) {
+        // Working icon
+        AppIconView(
+            iconURL: URL(string: "https://cdn.jsdelivr.net/gh/alielsokary/CaskFlow@icons/firefox.png")!,
+            name: "Firefox",
+            cacheKey: "caskflow-firefox"
+        )
+        // Monogram fallback (unresolvable URL)
+        AppIconView(
+            iconURL: URL(string: "https://example.invalid/nope.png")!,
+            name: "Some App",
+            cacheKey: "caskflow-some-app"
+        )
+    }
+    .padding()
 }

--- a/Applite/AppViews/IconAndDescriptionView.swift
+++ b/Applite/AppViews/IconAndDescriptionView.swift
@@ -14,10 +14,10 @@ struct IconAndDescriptionView: View {
     
     var body: some View {
         HStack {
-            if let iconURL = cask.iconURL, let faviconURL = cask.faviconURL {
+            if let iconURL = cask.iconURL {
                 AppIconView(
                     iconURL: iconURL,
-                    faviconURL: faviconURL,
+                    name: cask.name,
                     cacheKey: cask.iconCacheKey
                 )
                 .padding(.leading, 5)

--- a/Applite/Core/CaskCore/CaskViewModel.swift
+++ b/Applite/Core/CaskCore/CaskViewModel.swift
@@ -110,21 +110,20 @@ final class CaskViewModel {
 // MARK: - Icon URLs
 
 extension CaskViewModel {
-    /// Primary app-icon URL (App-Fair appcasks release asset).
+    /// Primary app-icon URL: CaskFlow's token-named icons (MIT), served via the jsDelivr CDN.
+    /// jsDelivr avoids the unauthenticated `raw.githubusercontent.com` rate limits that a
+    /// catalog full of icon loads would otherwise hit. Token characters (e.g. `+`) serve unencoded.
     ///
     /// Centralized here so every icon call site (app cards, the migration selection sheet) shares
     /// one source — the single edit point when the icon source is swapped.
     var iconURL: URL? {
-        URL(string: "https://github.com/App-Fair/appcasks/releases/download/cask-\(token)/AppIcon.png")
+        URL(string: "https://cdn.jsdelivr.net/gh/alielsokary/CaskFlow@icons/\(token).png")
     }
 
-    /// Fallback favicon URL derived from the homepage host.
-    var faviconURL: URL? {
-        URL(string: "https://icon.horse/icon/\(homepage?.host ?? "")")
-    }
-
-    /// Stable Kingfisher cache key for the icon.
-    var iconCacheKey: String { token }
+    /// Stable Kingfisher cache key for the icon. The `caskflow-` namespace deliberately differs
+    /// from the bare token used by the previous (App-Fair) icon source, so existing installs
+    /// re-fetch from CaskFlow instead of serving the old image cached under the plain token.
+    var iconCacheKey: String { "caskflow-\(token)" }
 }
 
 // MARK: -  Protocol conformances

--- a/Applite/Features/AppMigration/CaskSelectionSheet.swift
+++ b/Applite/Features/AppMigration/CaskSelectionSheet.swift
@@ -95,10 +95,10 @@ struct CaskSelectionSheet: View {
     private func row(for cask: CaskViewModel) -> some View {
         Toggle(isOn: binding(for: cask)) {
             HStack(spacing: 8) {
-                if let iconURL = cask.iconURL, let faviconURL = cask.faviconURL {
+                if let iconURL = cask.iconURL {
                     AppIconView(
                         iconURL: iconURL,
-                        faviconURL: faviconURL,
+                        name: cask.name,
                         cacheKey: cask.iconCacheKey,
                         size: 24
                     )

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -66,6 +66,7 @@
       "shouldTranslate" : false
     },
     "?" : {
+      "extractionState" : "stale",
       "localizations" : {
         "fr" : {
           "stringUnit" : {


### PR DESCRIPTION
## Summary

Replaces the app-icon pipeline. The old primary source — `github.com/App-Fair/appcasks` — is a **discontinued** project with stale, spotty coverage, and the fallback leaned on the third-party `icon.horse` favicon service.

- **Primary icons → CaskFlow** (`alielsokary/CaskFlow`, MIT), a daily-updated set of ~3,555 token-named 256px PNGs, served via **jsDelivr**. jsDelivr avoids the unauthenticated `raw.githubusercontent.com` rate limits that a catalog full of icon loads would otherwise hit; token characters like `+` serve unencoded (verified).
- **Fallback → generated monogram**, replacing `icon.horse`: the app's first letter in white on a deterministic color seeded from the cache key. No third-party favicon service, no privacy leak, works offline, and reads as intentional rather than a broken image.

## Why the cache-key bump

`AppIconView` keys Kingfisher by `cacheKey` for both the icon and its fallback. Existing installs have images cached under the bare `token` from the old App-Fair source, so `iconCacheKey` moves to a `caskflow-` namespace to force a one-time clean re-fetch; orphaned entries evict under Kingfisher's normal limits.

## Changes
- `CaskViewModel`: `iconURL` → CaskFlow/jsDelivr; `iconCacheKey` → `caskflow-<token>`; removed the unused `faviconURL`.
- `AppIconView`: 2-state chain (CaskFlow icon → monogram); takes `name` instead of `faviconURL`.
- `IconAndDescriptionView`, `CaskSelectionSheet`: updated call sites.

## Testing
- `xcodebuild … BUILD SUCCEEDED` (0 errors).
- Icon URLs verified out-of-band: jsDelivr returns `200 image/png` for normal and `+` tokens; a nonexistent token returns 404 → cleanly triggers the monogram fallback.
- Needs an in-app visual pass: common apps show CaskFlow icons; tap-only casks (not in CaskFlow) show a colored letter tile.

## Follow-up
CaskFlow attribution will land with the planned README "credit the alternatives" section (hot-linking fetches at runtime and doesn't redistribute their files, so MIT's attribution clause isn't strictly triggered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)