### PR TITLE
Point the in-app links at applite.app

### DIFF
--- a/Applite/App/Commands.swift
+++ b/Applite/App/Commands.swift
@@ -46,11 +46,11 @@ struct CommandsMenu: Commands {
         
         
         CommandGroup(replacing: .help) {
-            Link("Website", destination: URL(string: "https://aerolite.dev/applite")!)
-            Link("Troubleshooting", destination: URL(string: "https://aerolite.dev/applite/troubleshooting.html")!)
+            Link("Website", destination: URL(string: "https://applite.app")!)
+            Link("Troubleshooting", destination: URL(string: "https://applite.app/troubleshooting")!)
             Link("GitHub", destination: URL(string: "https://github.com/milanvarady/Applite")!)
             Link("Discord", destination: URL(string: "https://discord.gg/MpDMH9cPbK")!)
-            Link("Sponsor", destination: URL(string: "https://www.paypal.com/donate/?hosted_button_id=ZMDZSRG9CRY2Y")!)
+            Link("Sponsor", destination: URL(string: "https://applite.app/#support")!)
         }
     }
 }

--- a/Applite/Core/CaskCore/CaskViewModel.swift
+++ b/Applite/Core/CaskCore/CaskViewModel.swift
@@ -117,7 +117,7 @@ final class CaskViewModel {
             tap: "homebrew/cask",
             name: "Test",
             descriptionText: "Test application",
-            homepageURL: "https://aerolite.dev/",
+            homepageURL: "https://applite.app",
             pkgInstaller: false,
             warningType: nil,
             warningDate: nil,

--- a/Applite/Core/Models/CaskAdditionalInfo.swift
+++ b/Applite/Core/Models/CaskAdditionalInfo.swift
@@ -36,7 +36,7 @@ struct CaskAdditionalInfo: Codable, Hashable {
         token: "applite",
         full_token: "applite",
         tap: "homebrew/cask",
-        homepage: URL(string: "https://aerolite.dev/applite")!,
+        homepage: URL(string: "https://applite.app")!,
         url: URL(string: "https://github.com/milanvarady/Applite/releases/download/v1.2.5/Applite.dmg")!,
         installed: "1.2.5",
         bundle_version: "1.2.5",

--- a/Applite/Features/Bootstrap/ComponentsInstallView.swift
+++ b/Applite/Features/Bootstrap/ComponentsInstallView.swift
@@ -25,7 +25,7 @@ struct ComponentsInstallView: View {
 
     @Environment(\.openURL) private var openURL
 
-    private let troubleshootingURL = URL(string: "https://aerolite.dev/applite/troubleshooting.html")!
+    private let troubleshootingURL = URL(string: "https://applite.app/troubleshooting")!
 
     var body: some View {
         VStack(spacing: 16) {


### PR DESCRIPTION
The Help menu still sent people to `aerolite.dev`, now only a redirector, so every click took an extra hop to a domain being retired.

| Menu item | Was | Now |
|---|---|---|
| Website | `aerolite.dev/applite` | `applite.app` |
| Troubleshooting | `aerolite.dev/applite/troubleshooting.html` | `applite.app/troubleshooting` |
| Sponsor | PayPal donate link | `applite.app/#support` |

Also updates the troubleshooting link in `ComponentsInstallView`, which is what a user sees when the Homebrew bootstrap fails — the one that matters most, since it appears exactly when something has gone wrong.

**Sponsor points at the site, not at Ko-fi directly.** A menu item is compiled into the binary and cannot be changed once shipped, while that page can be edited any time. It also lets the reader choose between Ko-fi and GitHub Sponsors rather than choosing for them.

**Not changed:** the bundle identifier fallback in `UninstallSelf.swift` keeps `dev.aerolite.Applite`. Renaming the identifier would reset every user's settings, so it stays deliberately.

The two other hits were `static let dummy` SwiftUI preview fixtures. Updated so the retired domain does not linger in the source, but no user ever saw them.

Only future builds get these URLs; everything already installed keeps the old ones, which is what the `aerolite.dev` redirects are for. All five destinations verified live, including the `#support` anchor target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZEJ3XisHGixmdPA8myED2